### PR TITLE
Hotfix: Rebuild index button not working

### DIFF
--- a/client/src/components/SearchPage.jsx
+++ b/client/src/components/SearchPage.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import { projectsApi, searchApi } from '../services/api'
 import { formatDistanceToNow } from 'date-fns'
 import ClaudeMessageRenderer from './ClaudeMessageRenderer'
-import RebuildIndexButton from './RebuildIndexButton'
+import RebuildIndexModal from './RebuildIndexModal'
 import IndexStatusCard from './IndexStatusCard'
 import IndexStatusBadge from './IndexStatusBadge'
 
@@ -30,6 +30,11 @@ const SearchPage = () => {
   const { data: projectsData } = useQuery({
     queryKey: ['projects'],
     queryFn: () => projectsApi.getProjects().then(res => res.data)
+  })
+
+  const { data: indexStatus } = useQuery({
+    queryKey: ['indexStatus'],
+    queryFn: () => searchApi.getIndexStatus().then(res => res.data)
   })
 
   const handleSearch = async (e) => {
@@ -400,8 +405,8 @@ const SearchPage = () => {
                   <button
                     onClick={() => copyToClipboard(selectedMessage.content || selectedMessage.text || selectedMessage.snippet || '')}
                     className={`inline-flex items-center px-3 py-1.5 text-sm rounded transition-colors ${
-                      copySuccess 
-                        ? 'text-green-600 bg-green-50 border border-green-200' 
+                      copySuccess
+                        ? 'text-green-600 bg-green-50 border border-green-200'
                         : 'text-blue-600 hover:text-blue-800 hover:bg-blue-50'
                     }`}
                     title="Copy message to clipboard"
@@ -433,7 +438,7 @@ const SearchPage = () => {
                 </button>
               </div>
             </div>
-            
+
             {/* Copy Success Message */}
             {copySuccess && (
               <div className="px-4 py-2 bg-green-50 border-b border-green-200">
@@ -445,7 +450,7 @@ const SearchPage = () => {
                 </div>
               </div>
             )}
-            
+
             <div className="p-4 overflow-y-auto max-h-[calc(90vh-120px)]">
               {isLoadingMessage ? (
                 <div className="flex items-center justify-center py-12">
@@ -472,7 +477,7 @@ const SearchPage = () => {
                       </span>
                     )}
                   </div>
-                  
+
                   <div className="prose prose-sm max-w-none">
                     {selectedMessage.content || selectedMessage.text ? (
                       <ClaudeMessageRenderer
@@ -492,6 +497,13 @@ const SearchPage = () => {
           </div>
         </div>
       )}
+
+      {/* Rebuild Index Modal */}
+      <RebuildIndexModal
+        isOpen={showRebuildModal}
+        onClose={() => setShowRebuildModal(false)}
+        currentStats={indexStatus?.stats}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 🐛 Bug Fix - Rebuild Index Button

**Type**: Hotfix  
**Target**: v1.1.0 (post-release fix)  
**Priority**: Medium

---

## Problem

The "Rebuild Index" button on the search page was not functional:
- Clicking the button had no effect
- `RebuildIndexModal` was not imported or rendered
- Index status was not being fetched for modal stats

---

## Changes

**File Modified**: `client/src/components/SearchPage.jsx`

1. **Import Fix**:
   - Changed from `RebuildIndexButton` to `RebuildIndexModal`
   
2. **Added Index Status Query**:
   ```javascript
   const { data: indexStatus } = useQuery({
     queryKey: ['indexStatus'],
     queryFn: () => searchApi.getIndexStatus().then(res => res.data)
   })
   ```

3. **Rendered Modal**:
   ```javascript
   <RebuildIndexModal
     isOpen={showRebuildModal}
     onClose={() => setShowRebuildModal(false)}
     currentStats={indexStatus?.stats}
   />
   ```

---

## Impact

✅ Users can now rebuild FTS5 search index from the UI  
✅ Modal displays current index stats (messages, projects, sessions)  
✅ Progress, success, and error states work correctly  
✅ Backend endpoints verified working:
   - `POST /api/search/index/build`
   - `GET /api/search/index/status`

---

## Testing

- [x] Manually tested rebuild index button click
- [x] Verified modal opens with stats
- [x] Confirmed backend endpoints exist and work
- [x] Verified API methods in searchApi

---

## Deployment

This is a frontend-only fix, no backend changes required.

**Safe to merge**: Yes - fixes broken functionality without side effects