### PR TITLE
fix: Use HTML img tags for README screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 ## 📸 Screenshots
 
 ### Home & Conversation View
-![Conversation View](./screenshots/conversation-view.png)
+<img src="screenshots/conversation-view.png" alt="Conversation View" width="800">
 
 ### Full-Text Search
-![Search Results](./screenshots/search-results.png)
+<img src="screenshots/search-results.png" alt="Search Results" width="800">
 
 ## ✨ Features
 


### PR DESCRIPTION
## Problem
Screenshots still showing broken image icons even after optimization. Research shows GitHub routes Markdown images through `camo.githubusercontent.com` proxy which causes 302 redirects and CSP blocking.

## Root Cause
- GitHub's Content Security Policy blocks 302 redirects to external domains
- Markdown syntax `![](...)` gets routed through camo proxy
- Proxy can cause rendering issues with repository images

## Solution
Replace Markdown image syntax with HTML `<img>` tags:
- ✅ Bypasses camo.githubusercontent.com proxy issues
- ✅ Direct repository-relative paths work better
- ✅ Explicit width control (800px) for consistent rendering
- ✅ Better compatibility with GitHub's CSP

## Changes
```diff
- ![Conversation View](./screenshots/conversation-view.png)
+ <img src="screenshots/conversation-view.png" alt="Conversation View" width="800">
```

## References
- GitHub Community Discussion #77343 (Image files not displaying)
- GitHub Community Discussion #165090 (README images bug)
- Stack Overflow: 302 redirect blocking for README images

This is a well-documented GitHub issue with HTML img tags being the recommended solution.