### PR TITLE
fix: Use static MIT badge for immediate display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   Claudex is a full-stack web application designed for developers, QA engineers, and researchers who need to inspect, search, and analyze Claude Code conversation histories. Built with React and Fastify, it provides enterprise-grade full-text search using SQLite FTS5, universal template support for all Claude Code versions, and comprehensive analytics dashboards.
 
   [![Version](https://img.shields.io/github/v/release/kunwar-shah/claudex)](https://github.com/kunwar-shah/claudex/releases)
-  [![License](https://img.shields.io/github/license/kunwar-shah/claudex)](https://github.com/kunwar-shah/claudex/blob/main/LICENSE)
+  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/kunwar-shah/claudex/blob/main/LICENSE)
   [![Documentation](https://img.shields.io/badge/docs-github--pages-blue)](https://kunwar-shah.github.io/claudex/)
   [![Discussions](https://img.shields.io/github/discussions/kunwar-shah/claudex)](https://github.com/kunwar-shah/claudex/discussions)
 


### PR DESCRIPTION
## Issue

LICENSE badge still showing "not specified" after PR #11.

## Root Cause

GitHub's license detection API () can take **hours or even days** to update after adding a LICENSE file. The badge depends on GitHub's Licensee library indexing the repository.

## Solution

Use a **static badge** that explicitly says "MIT" instead of relying on GitHub API detection:

**Before**:
```markdown
[![License](https://img.shields.io/github/license/kunwar-shah/claudex)](...)
```
Result: "license not specified" ❌

**After**:
```markdown
[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](...)
```
Result: "MIT" badge (yellow) ✅

## Benefits

- ✅ Shows "MIT" immediately (no waiting for GitHub indexing)
- ✅ Standard color scheme (yellow for licenses)
- ✅ Still links to LICENSE file on GitHub
- ✅ Reliable and doesn't depend on API caching

## Preview

Badge will display: ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)