### PR TITLE
v1.3.2: honest package description

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,20 +2,31 @@
 
 All notable changes to Claudex.
 
+## [1.3.2] - 2026-04-30
+
+### Changed
+- **Honest package description** — clarified that Claudex specifically indexes `~/.claude/projects/` (Claude Code JSONL format). The MCP server is consumable by any MCP-compatible client, but the data layer is Claude-Code-only. Previous wording could imply broader scope than is accurate.
+
+### Notes
+- v1.3.1 was tagged but not published to npm; v1.3.2 is the first refreshed publish. No functional changes since v1.3.0.
+
+---
+
 ## [1.3.1] - 2026-04-30
 
 ### Added
 - **Hero GIF in README** — animated 18-second walkthrough showing browse, search, and MCP memory tools (PR #39, contributed by @livlign via [Anthropic repo-visuals](https://github.com/anthropics/skills/tree/main/repo-visuals))
 - **GitHub Sponsors** enabled — `Sponsor` button now visible on the repo
-- **Expanded npm keywords** — added `mcp`, `mcp-server`, `model-context-protocol`, `ai-memory`, `agent-memory`, `persistent-memory`, `cursor`, `codex`, `windsurf`, and more for better discoverability
-- **Updated package description** — emphasizes MCP-powered persistent memory and cross-agent compatibility
+- **Expanded npm keywords** — added `mcp`, `mcp-server`, `model-context-protocol`, `ai-memory`, `agent-memory`, `persistent-memory`, and more for better discoverability
+- **Updated package description** — emphasizes MCP-powered persistent memory
 
 ### Changed
 - Refreshed `ROADMAP.md` with v1.4.0 / v2.0 / v3.0 milestones (Pro tier, cross-project intelligence, Claudex Cloud)
 - Updated package metadata to reflect MCP-first positioning
 
 ### Notes
-- This is a metadata + documentation release. No functional changes from v1.3.0; safe upgrade.
+- This was a metadata + documentation release. No functional changes from v1.3.0.
+- Tagged in git but **not published to npm** — superseded by v1.3.2 with clearer description.
 - Pinned `v2.0 Roadmap — Cross-Project Intelligence` discussion for community feedback.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kunwarshah/claudex",
-  "version": "1.3.1",
-  "description": "MCP-powered persistent memory + full-text search for Claude Code. Make AI agents (Claude Code, Cursor, Codex) remember conversations, decisions, and conventions across sessions.",
+  "version": "1.3.2",
+  "description": "Persistent memory + FTS5 search for Claude Code conversations. MCP server exposes your ~/.claude/projects/ history as queryable memory for any MCP-compatible AI agent.",
   "main": "index.js",
   "bin": {
     "claudex": "./bin/claude-viewer.js",


### PR DESCRIPTION
## Summary

Clarifies the package description to be honest about scope.

## What changed

**Description (before)** — could imply broader scope:
> "MCP-powered persistent memory + full-text search for Claude Code. Make AI agents (Claude Code, Cursor, Codex) remember conversations, decisions, and conventions across sessions."

**Description (after)** — accurate:
> "Persistent memory + FTS5 search for Claude Code conversations. MCP server exposes your ~/.claude/projects/ history as queryable memory for any MCP-compatible AI agent."

The truth: Claudex indexes `~/.claude/projects/` (Claude Code's JSONL format). Cursor/Codex/Windsurf have entirely different conversation storage. They CAN consume Claudex's MCP server (the protocol is universal), but the data layer is Claude-Code-only.

## Why two patch versions in one day

v1.3.1 was tagged in git but never published to npm (build failed locally without `npm install`). v1.3.2 supersedes it before any npm publish — clean version on the registry.

## Test plan

- [ ] No code changes; description-only fix
- [ ] After local `npm install && npm publish`, verify npm page reflects new description