### PR TITLE
v1.3.3 — MCP Registry + major UX polish

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,43 +1,74 @@
-import React, { useState } from 'react'
+import React, { Suspense, lazy } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Layout from './components/Layout'
-import ProjectView from './components/ProjectView'
-import TremorProjectView from './components/TremorProjectView'
-import SearchPage from './components/SearchPage'
-import SessionManagementPage from './pages/SessionManagementPage'
-import Toast from './components/Toast'
+import { TopProgressBar, LoadingScreen } from './components/ui/loading'
 import './App.css'
 
+// Code-split routes into separate chunks — loaded only when navigated to.
+// Initial bundle drops to just Layout + Header + Footer + LoadingScreen.
+const ProjectView           = lazy(() => import('./components/ProjectView'))
+const TremorProjectView     = lazy(() => import('./components/TremorProjectView'))
+const SearchPage            = lazy(() => import('./components/SearchPage'))
+const SessionManagementPage = lazy(() => import('./pages/SessionManagementPage'))
+
+// Global toasts now live in <ToastProvider> (mounted in main.jsx).
+// Use `useToast()` from any component to fire a notification.
+
 function App() {
-  const [toast, setToast] = useState(null) // { type, message }
-
-  // Auto-index disabled — users can manually rebuild from Search page.
-  // TODO: Re-enable with smarter triggering (not on every page load)
-
   return (
     <div className="App">
+      {/* Global indeterminate progress bar — activates whenever ANY query/mutation is fetching */}
+      <TopProgressBar />
+
       <Routes>
         <Route path="/" element={<Layout />}>
-          <Route index element={<ProjectView />} />
-          <Route path="projects/:projectId" element={<ProjectView />} />
-          <Route path="projects/:projectId/sessions/:sessionId" element={<ProjectView />} />
-          <Route path="search" element={<SearchPage />} />
-          <Route path="manage-sessions" element={<SessionManagementPage />} />
-          <Route path="manage-sessions/:projectId" element={<SessionManagementPage />} />
-          <Route path="tremor-preview" element={<TremorProjectView />} />
-          <Route path="tremor-preview/projects/:projectId" element={<TremorProjectView />} />
-          <Route path="tremor-preview/projects/:projectId/sessions/:sessionId" element={<TremorProjectView />} />
+          <Route index element={
+            <Suspense fallback={<LoadingScreen label="Loading workspace…" />}>
+              <ProjectView />
+            </Suspense>
+          } />
+          <Route path="projects/:projectId" element={
+            <Suspense fallback={<LoadingScreen label="Loading workspace…" />}>
+              <ProjectView />
+            </Suspense>
+          } />
+          <Route path="projects/:projectId/sessions/:sessionId" element={
+            <Suspense fallback={<LoadingScreen label="Loading workspace…" />}>
+              <ProjectView />
+            </Suspense>
+          } />
+          <Route path="search" element={
+            <Suspense fallback={<LoadingScreen label="Loading search…" />}>
+              <SearchPage />
+            </Suspense>
+          } />
+          <Route path="manage-sessions" element={
+            <Suspense fallback={<LoadingScreen label="Loading session manager…" />}>
+              <SessionManagementPage />
+            </Suspense>
+          } />
+          <Route path="manage-sessions/:projectId" element={
+            <Suspense fallback={<LoadingScreen label="Loading session manager…" />}>
+              <SessionManagementPage />
+            </Suspense>
+          } />
+          <Route path="tremor-preview" element={
+            <Suspense fallback={<LoadingScreen label="Loading analytics dashboard…" />}>
+              <TremorProjectView />
+            </Suspense>
+          } />
+          <Route path="tremor-preview/projects/:projectId" element={
+            <Suspense fallback={<LoadingScreen label="Loading analytics…" />}>
+              <TremorProjectView />
+            </Suspense>
+          } />
+          <Route path="tremor-preview/projects/:projectId/sessions/:sessionId" element={
+            <Suspense fallback={<LoadingScreen label="Loading analytics…" />}>
+              <TremorProjectView />
+            </Suspense>
+          } />
         </Route>
       </Routes>
-
-      {/* Toast Notification */}
-      {toast && (
-        <Toast
-          type={toast.type}
-          message={toast.message}
-          onClose={() => setToast(null)}
-        />
-      )}
     </div>
   )
 }

--- a/client/src/components/ConversationThread.jsx
+++ b/client/src/components/ConversationThread.jsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { projectsApi, sessionMetadataApi } from '../services/api'
 import MessageBubble from './MessageBubble'
+import { LoadingScreen } from './ui/loading'
 import MessagingBubble from './MessagingBubble'
 import ExportButton from './ExportButton'
 import { Button } from './ui/button'
@@ -106,9 +107,10 @@ const ConversationThread = ({ projectId, sessionId, highlightMessageId }) => {
 
   if (isLoading) {
     return (
-      <div className="h-full flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      <LoadingScreen
+        label="Loading conversation..."
+        description="Fetching messages from the session log."
+      />
     )
   }
 
@@ -248,7 +250,7 @@ const ConversationThread = ({ projectId, sessionId, highlightMessageId }) => {
                   <select
                     value={pageSize}
                     onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                    className="h-7 rounded-md border border-border bg-background px-2 text-xs"
+                    className="h-8 rounded-md border border-border bg-background pl-2.5 pr-7 text-xs min-w-[68px] cursor-pointer hover:border-primary/50 transition-colors"
                   >
                     <option value={25}>25</option>
                     <option value={50}>50</option>

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { AlertTriangle, RefreshCw, Home, ExternalLink } from 'lucide-react'
+
+/**
+ * ErrorBoundary — root-level safety net.
+ *
+ * Catches JavaScript errors anywhere in the tree, logs them, and shows a
+ * recoverable error UI instead of a white screen.
+ *
+ * Required to be a class component (React's API).
+ *
+ * Usage in main.jsx:
+ *   <ErrorBoundary>
+ *     <App />
+ *   </ErrorBoundary>
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null, errorInfo: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Log to console with full context for dev debugging
+    console.error('[Claudex ErrorBoundary] Caught error:', error)
+    console.error('[Claudex ErrorBoundary] Component stack:', errorInfo.componentStack)
+    this.setState({ errorInfo })
+
+    // Future: report to error tracking service (Sentry/LogRocket)
+    // window.__claudexErrorReporter?.(error, errorInfo)
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null })
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  handleHome = () => {
+    window.location.href = '/'
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    const { error, errorInfo } = this.state
+    const isDev = import.meta.env?.DEV ?? false
+    const errorTitle = error?.name || 'Error'
+    const errorMessage = error?.message || 'An unexpected error occurred'
+    const stack = error?.stack || ''
+
+    // Build a GitHub Issue URL with pre-populated body
+    const issueBody = encodeURIComponent(`## Error
+${errorTitle}: ${errorMessage}
+
+## Stack
+\`\`\`
+${stack.slice(0, 1500)}
+\`\`\`
+
+## Component Stack
+\`\`\`
+${(errorInfo?.componentStack || 'unknown').slice(0, 1500)}
+\`\`\`
+
+## Browser
+${navigator.userAgent}
+
+## URL
+${window.location.href}
+`)
+    const issueUrl = `https://github.com/kunwar-shah/claudex/issues/new?title=${encodeURIComponent('[Bug] ' + errorTitle)}&body=${issueBody}`
+
+    return (
+      <div className="min-h-screen bg-zinc-50 flex items-center justify-center p-6">
+        <div className="max-w-2xl w-full bg-white rounded-xl shadow-xl border border-zinc-200 overflow-hidden">
+          {/* Header strip */}
+          <div className="bg-gradient-to-r from-red-500 to-red-600 px-6 py-4 flex items-center gap-3">
+            <AlertTriangle className="w-6 h-6 text-white flex-shrink-0" aria-hidden="true" />
+            <h1 className="text-lg font-semibold text-white">Something went wrong</h1>
+          </div>
+
+          {/* Body */}
+          <div className="p-6 space-y-4">
+            <p className="text-zinc-700">
+              Claudex hit an unexpected error and couldn't continue. Your data is safe — this is a UI-only crash.
+            </p>
+
+            <div className="rounded-md bg-red-50 border border-red-200 p-4">
+              <div className="text-sm font-mono text-red-900 break-words">
+                <span className="font-semibold">{errorTitle}:</span> {errorMessage}
+              </div>
+            </div>
+
+            {/* Show stack only in dev */}
+            {isDev && stack && (
+              <details className="text-xs">
+                <summary className="cursor-pointer text-zinc-500 hover:text-zinc-700 font-medium">
+                  Show technical details (dev mode)
+                </summary>
+                <pre className="mt-2 p-3 bg-zinc-100 rounded text-zinc-700 overflow-x-auto max-h-64 overflow-y-auto">
+                  {stack}
+                  {errorInfo?.componentStack && '\n\nComponent Stack:' + errorInfo.componentStack}
+                </pre>
+              </details>
+            )}
+
+            <div className="text-sm text-zinc-600">
+              You can try the actions below. If the error keeps happening, please report it.
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex flex-wrap gap-2 pt-2">
+              <button
+                onClick={this.handleReset}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-emerald-600 text-white hover:bg-emerald-700 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+              >
+                <RefreshCw className="w-4 h-4" aria-hidden="true" />
+                Try Again
+              </button>
+              <button
+                onClick={this.handleReload}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-zinc-100 text-zinc-700 hover:bg-zinc-200 border border-zinc-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2"
+              >
+                <RefreshCw className="w-4 h-4" aria-hidden="true" />
+                Reload Page
+              </button>
+              <button
+                onClick={this.handleHome}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-zinc-100 text-zinc-700 hover:bg-zinc-200 border border-zinc-300 transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2"
+              >
+                <Home className="w-4 h-4" aria-hidden="true" />
+                Go Home
+              </button>
+              <a
+                href={issueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md text-primary hover:bg-primary/5 border border-primary/30 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              >
+                <ExternalLink className="w-4 h-4" aria-hidden="true" />
+                Report Issue
+              </a>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="bg-zinc-50 border-t border-zinc-200 px-6 py-3 text-xs text-zinc-500">
+            Claudex v1.3.2 · Error caught by ErrorBoundary
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/client/src/components/ExportButton.jsx
+++ b/client/src/components/ExportButton.jsx
@@ -94,6 +94,9 @@ const ExportButton = ({ projectId, sessionId, sessionTitle, variant = 'default' 
         disabled={isExporting}
         className={buttonClasses}
         title="Export conversation"
+        aria-label="Export conversation"
+        aria-haspopup="menu"
+        aria-expanded={showDropdown}
       >
         {isExporting ? (
           <>

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -5,9 +5,11 @@ import { Copy, ArrowUp, ArrowDown, Github, BookOpen, Activity } from 'lucide-rea
 import { projectsApi } from '../services/api'
 import ExportButton from './ExportButton'
 import { Button } from './ui/button'
+import { useToast } from '../contexts/ToastContext'
 
 const Footer = () => {
   const { projectId, sessionId } = useParams()
+  const toast = useToast()
   
   const { data: sessionData } = useQuery({
     queryKey: ['session', projectId, sessionId],
@@ -95,30 +97,16 @@ ${technicalMessages
 *Context extracted from Claude Conversations Viewer for AI continuity*`
 
       await navigator.clipboard.writeText(contextText)
-      
-      // Show success message
-      const toast = document.createElement('div')
-      toast.className = 'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-md shadow-lg z-50 animate-fade-in'
-      toast.textContent = 'Project context copied for Claude Code!'
-      document.body.appendChild(toast)
-      
-      setTimeout(() => {
-        document.body.removeChild(toast)
-      }, 3000)
-      
+      toast.success('Project context copied for Claude Code!', {
+        title: 'Copied',
+        duration: 3000,
+      })
       console.log('Project context copied to clipboard')
     } catch (error) {
       console.error('Failed to copy project context:', error)
-      
-      // Show error message
-      const toast = document.createElement('div')
-      toast.className = 'fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded-md shadow-lg z-50'
-      toast.textContent = 'Failed to copy context: ' + error.message
-      document.body.appendChild(toast)
-      
-      setTimeout(() => {
-        document.body.removeChild(toast)
-      }, 3000)
+      toast.error(error.message || 'Could not copy context to clipboard', {
+        title: 'Copy failed',
+      })
     }
   }
 
@@ -166,7 +154,7 @@ ${technicalMessages
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
             <span className="text-xs text-text-tertiary font-medium">
-              Claudex v1.2
+              Claudex v1.3.2
             </span>
 
             <a

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -71,10 +71,11 @@ const Header = () => {
             variant="ghost"
             size="icon"
             title="Settings"
+            aria-label="Open settings"
             className="text-white hover:bg-[hsl(var(--surface))]/20 hover:text-white"
             onClick={() => setSettingsOpen(true)}
           >
-            <Settings className="w-4 h-4" />
+            <Settings className="w-4 h-4" aria-hidden="true" />
           </Button>
         </nav>
 

--- a/client/src/components/KeyboardShortcutsHelp.jsx
+++ b/client/src/components/KeyboardShortcutsHelp.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { X, Keyboard } from 'lucide-react'
+
+/**
+ * KeyboardShortcutsHelp — modal overlay listing all available shortcuts.
+ * Triggered by `?` keypress (registered in Layout via useKeyboardShortcuts).
+ */
+const SHORTCUTS = [
+  {
+    section: 'General',
+    items: [
+      { keys: ['?'], description: 'Show this help' },
+      { keys: ['Esc'], description: 'Close any modal' },
+      { keys: ['/'], description: 'Focus search input' },
+      { keys: ['Cmd', 'K'], description: 'Open command palette (coming soon)' },
+      { keys: ['Cmd', ','], description: 'Open settings' },
+    ],
+  },
+  {
+    section: 'Navigation',
+    items: [
+      { keys: ['g', 's'], description: 'Go to Search' },
+      { keys: ['g', 'm'], description: 'Go to Manage Sessions' },
+      { keys: ['g', 'a'], description: 'Go to Analytics' },
+    ],
+  },
+]
+
+export default function KeyboardShortcutsHelp({ isOpen, onClose }) {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50 p-4 animate-fade-in"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kb-shortcuts-title"
+    >
+      <div
+        className="w-full max-w-md bg-white dark:bg-zinc-900 rounded-xl shadow-2xl ring-1 ring-black/10 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="bg-gradient-to-r from-primary to-primary-dark px-5 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-white">
+            <Keyboard className="w-5 h-5" aria-hidden="true" />
+            <h2 id="kb-shortcuts-title" className="text-lg font-semibold">
+              Keyboard Shortcuts
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts"
+            className="text-white/80 hover:text-white p-1 rounded hover:bg-white/15 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 max-h-[60vh] overflow-y-auto">
+          {SHORTCUTS.map((section, sectionIdx) => (
+            <div key={section.section} className={sectionIdx > 0 ? 'mt-5 pt-5 border-t border-border' : ''}>
+              <div className="text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-3">
+                {section.section}
+              </div>
+              <ul className="space-y-2.5">
+                {section.items.map((item, idx) => (
+                  <li key={idx} className="flex items-center justify-between gap-3">
+                    <span className="text-sm text-text-primary">{item.description}</span>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      {item.keys.map((k, ki) => (
+                        <React.Fragment key={ki}>
+                          {ki > 0 && <span className="text-xs text-text-tertiary mx-0.5">+</span>}
+                          <kbd className="px-1.5 py-0.5 text-xs font-mono font-semibold bg-zinc-100 dark:bg-zinc-800 text-text-primary border border-border rounded shadow-sm min-w-[24px] text-center">
+                            {k}
+                          </kbd>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 bg-surface border-t border-border text-xs text-text-tertiary text-center">
+          Press <kbd className="px-1 py-0.5 bg-zinc-100 dark:bg-zinc-800 rounded text-[10px]">Esc</kbd> to close
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,9 +1,38 @@
-import React from 'react'
-import { Outlet } from 'react-router-dom'
+import React, { useState, useCallback } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
+import KeyboardShortcutsHelp from './KeyboardShortcutsHelp'
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 
 const Layout = () => {
+  const navigate = useNavigate()
+  const [helpOpen, setHelpOpen] = useState(false)
+
+  // Focus the first visible search input on the page (if any)
+  const focusSearch = useCallback(() => {
+    const search = document.querySelector(
+      'input[type="search"], input[placeholder*="Search" i], input[placeholder*="search" i]'
+    )
+    if (search) search.focus()
+  }, [])
+
+  // Esc closes help; consumers can also listen on their own
+  const handleEscape = useCallback(() => {
+    if (helpOpen) setHelpOpen(false)
+  }, [helpOpen])
+
+  useKeyboardShortcuts({
+    onShowHelp:       () => setHelpOpen(true),
+    onFocusSearch:    focusSearch,
+    onEscape:         handleEscape,
+    onCommandPalette: () => {/* TODO: Cmd+K palette */},
+    onOpenSettings:   () => {/* Settings is owned by Header — would need lift state */},
+    onGoSearch:       () => navigate('/search'),
+    onGoManage:       () => navigate('/manage-sessions'),
+    onGoAnalytics:    () => navigate('/tremor-preview'),
+  })
+
   return (
     <div className="flex flex-col h-screen">
       <Header />
@@ -11,6 +40,9 @@ const Layout = () => {
         <Outlet />
       </main>
       <Footer />
+
+      {/* Keyboard shortcuts overlay (triggered by ?) */}
+      <KeyboardShortcutsHelp isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   )
 }

--- a/client/src/components/ProjectExportButton.jsx
+++ b/client/src/components/ProjectExportButton.jsx
@@ -58,6 +58,7 @@ const ProjectExportButton = ({ projectId, projectName, variant = 'default' }) =>
       disabled={isExporting}
       className={buttonClasses}
       title={`Export complete project: ${projectName || projectId}`}
+      aria-label={`Export project ${projectName || projectId} as JSON`}
     >
       {isExporting ? (
         <>

--- a/client/src/components/SearchPage.jsx
+++ b/client/src/components/SearchPage.jsx
@@ -23,6 +23,7 @@ import { Card, CardContent } from './ui/card'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
+import { LoadingScreen, ListLoadingItems } from './ui/loading'
 import { H1, Muted, Small } from './ui/typography'
 import EmptyState from './layout/EmptyState'
 import { cn } from '@/lib/utils'
@@ -322,9 +323,13 @@ const SearchPage = () => {
       <div className="flex-1 overflow-y-auto p-4">
         <div className="max-w-6xl mx-auto">
           {isSearching && (
-            <div className="text-center py-12">
-              <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-3" />
-              <Muted>Searching conversations...</Muted>
+            <div>
+              <LoadingScreen
+                label="Searching conversations..."
+                description="Running FTS5 query across your conversation history"
+                className="py-8"
+              />
+              <ListLoadingItems count={5} hasIcon={true} className="mt-2" />
             </div>
           )}
 
@@ -495,10 +500,7 @@ const SearchPage = () => {
 
             <CardContent className="p-4 overflow-y-auto max-h-[calc(90vh-120px)]">
               {isLoadingMessage ? (
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="w-6 h-6 animate-spin text-primary mr-3" />
-                  <Muted>Loading full message...</Muted>
-                </div>
+                <LoadingScreen label="Loading full message..." className="py-8"/>
               ) : selectedMessage?.error ? (
                 <div className="text-center py-8">
                   <AlertCircle className="w-8 h-8 text-error mx-auto mb-2" />

--- a/client/src/components/SessionList.jsx
+++ b/client/src/components/SessionList.jsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from './ui/card'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
 import { Muted, Small } from './ui/typography'
+import { ListLoadingItems } from './ui/loading'
 import { cn } from '@/lib/utils'
 
 const SessionList = ({ projectId, selectedSessionId }) => {
@@ -41,10 +42,8 @@ const SessionList = ({ projectId, selectedSessionId }) => {
 
   if (isLoading) {
     return (
-      <div className="p-4 space-y-3">
-        {[...Array(6)].map((_, i) => (
-          <div key={i} className="h-20 bg-surface animate-pulse rounded-lg border border-border"></div>
-        ))}
+      <div className="p-4">
+        <ListLoadingItems count={6} hasIcon={true} />
       </div>
     )
   }

--- a/client/src/components/SessionMetadataControls.jsx
+++ b/client/src/components/SessionMetadataControls.jsx
@@ -162,7 +162,7 @@ const SessionMetadataControls = ({ projectId, sessionId, currentTitle, compact =
               value={customTitle}
               onChange={(e) => setCustomTitle(e.target.value)}
               placeholder={currentTitle}
-              className="flex-1 px-3 py-2 border border-[hsl(var(--border-hover))] rounded text-sm"
+              className="flex-1 min-w-0 px-3 py-2 border border-[hsl(var(--border-hover))] rounded text-sm"
               autoFocus
             />
             <button
@@ -250,7 +250,7 @@ const SessionMetadataControls = ({ projectId, sessionId, currentTitle, compact =
             value={tagInput}
             onChange={(e) => setTagInput(e.target.value)}
             placeholder="Add tags (comma-separated)"
-            className="flex-1 px-3 py-2 border border-[hsl(var(--border-hover))] rounded text-sm"
+            className="flex-1 min-w-0 px-3 py-2 border border-[hsl(var(--border-hover))] rounded text-sm"
             onKeyPress={(e) => e.key === 'Enter' && handleAddTags()}
           />
           <button

--- a/client/src/components/SessionSummaryModal.jsx
+++ b/client/src/components/SessionSummaryModal.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { X, FileText, ChevronDown, Settings, Edit, MessageSquare } from 'lucide-react'
 import { projectsApi, sessionMetadataApi } from '../services/api'
+import { ModalLoadingContent } from './ui/loading'
 
 /**
  * SessionSummaryModal - Modal dialog showing session summary
@@ -95,22 +96,18 @@ const SessionSummaryModal = ({ session, projectId, onClose }) => {
             </div>
             <button
               onClick={onClose}
-              className="ml-4 p-2 hover:bg-surface rounded-lg transition-colors"
+              aria-label="Close session summary"
+              title="Close"
+              className="ml-4 p-2 hover:bg-surface rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
             >
-              <X className="w-5 h-5 text-muted-foreground" />
+              <X className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
             </button>
           </div>
 
           {/* Content */}
           <div className="flex-1 overflow-y-auto p-6">
             {isLoading ? (
-              <div className="animate-pulse space-y-4">
-                <div className="h-4 bg-surface rounded w-3/4"></div>
-                <div className="space-y-2">
-                  <div className="h-3 bg-surface rounded"></div>
-                  <div className="h-3 bg-surface rounded w-5/6"></div>
-                </div>
-              </div>
+              <ModalLoadingContent label="Loading session summary..." />
             ) : error ? (
               <div className="text-error text-sm">
                 Failed to load session summary

--- a/client/src/components/SettingsModal.jsx
+++ b/client/src/components/SettingsModal.jsx
@@ -1,8 +1,87 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { X, Palette, Search, Eye, Settings as SettingsIcon, FolderOpen, Database } from 'lucide-react'
 import { useSettings } from '../contexts/SettingsContext'
 import { Button } from './ui/button'
 import ConfirmationModal from './ConfirmationModal'
+
+// All available themes with rich color metadata for the preview block.
+// Each theme includes: primary, primaryDark, surface, text, textMuted, badge.
+const THEMES = [
+  { id: 'default', name: 'Default', primary: '#475569', primaryDark: '#334155', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#f1f5f9' },
+  { id: 'emerald', name: 'Emerald', primary: '#10b981', primaryDark: '#059669', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#ecfdf5' },
+  { id: 'green',   name: 'Green',   primary: '#16a34a', primaryDark: '#15803d', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#f0fdf4' },
+  { id: 'blue',    name: 'Blue',    primary: '#2563eb', primaryDark: '#1d4ed8', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#eff6ff' },
+  { id: 'purple',  name: 'Purple',  primary: '#9333ea', primaryDark: '#7e22ce', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#faf5ff' },
+  { id: 'orange',  name: 'Orange',  primary: '#f97316', primaryDark: '#ea580c', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#fff7ed' },
+  { id: 'red',     name: 'Red',     primary: '#ef4444', primaryDark: '#dc2626', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#fef2f2' },
+  { id: 'rose',    name: 'Rose',    primary: '#fb7185', primaryDark: '#e11d48', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#fff1f2' },
+  { id: 'yellow',  name: 'Yellow',  primary: '#eab308', primaryDark: '#ca8a04', surface: '#ffffff', text: '#0f172a', textMuted: '#64748b', badgeBg: '#fefce8' },
+  { id: 'classic', name: 'Classic', primary: '#5B8DEF', primaryDark: '#3b6cd6', surface: '#FCFCFD', text: '#0f172a', textMuted: '#64748b', badgeBg: '#f0f5ff' },
+]
+
+// All visual settings that can be randomized
+const RANDOMIZABLE_OPTIONS = {
+  colorTheme:       THEMES.map(t => t.id),
+  fontFamily:       ['inter', 'geist', 'roboto', 'poppins', 'montserrat', 'open-sans', 'lato', 'raleway', 'nunito', 'ubuntu', 'rubik', 'dm-sans', 'work-sans', 'space-grotesk', 'quicksand', 'karla', 'outfit', 'jakarta', 'manrope', 'lexend', 'archivo', 'system'],
+  fontSize:         ['small', 'small-medium', 'medium', 'medium-large', 'large'],
+  density:          ['compact', 'comfortable', 'spacious'],
+  borderRadius:     ['sharp', 'rounded', 'extra-rounded'],
+  conversationView: ['detailed', 'messaging'],
+}
+
+// Mini theme preview block — renders a small mock UI in the theme's colors.
+// Replaces the global CSS swap on hover. Pure inline styles, no theme-context.
+function ThemePreviewCard({ theme, isActive, isHovered, onClick, onHover, onLeave }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={onHover}
+      onMouseLeave={onLeave}
+      aria-pressed={isActive}
+      aria-label={`Theme: ${theme.name}${isActive ? ' (currently selected)' : ''}`}
+      className={`group relative p-2 rounded-lg border-2 transition-all duration-200 text-left ${
+        isActive
+          ? 'border-primary ring-2 ring-primary/20 shadow-md'
+          : 'border-border hover:border-primary/40 hover:shadow-sm'
+      } ${isHovered ? 'scale-[1.03]' : ''}`}
+    >
+      {/* Mini mockup of the theme — rendered with inline styles */}
+      <div
+        className="w-full h-14 rounded-md overflow-hidden flex flex-col mb-1.5 ring-1 ring-black/5"
+        style={{ background: theme.surface }}
+      >
+        {/* Mock header bar with primary color */}
+        <div
+          className="h-3 flex items-center px-1.5 gap-0.5"
+          style={{ background: theme.primary }}
+        >
+          <div className="w-1 h-1 rounded-full bg-white/70" />
+          <div className="w-1 h-1 rounded-full bg-white/70" />
+          <div className="w-1 h-1 rounded-full bg-white/70" />
+        </div>
+        {/* Mock body — text + button + badge */}
+        <div className="flex-1 px-1.5 py-1 flex items-center gap-1">
+          <div className="flex-1 space-y-0.5">
+            <div className="h-1 rounded-full" style={{ background: theme.text, opacity: 0.7, width: '70%' }} />
+            <div className="h-1 rounded-full" style={{ background: theme.textMuted, opacity: 0.5, width: '50%' }} />
+          </div>
+          <div
+            className="rounded text-[5px] font-bold px-1 py-0.5 flex-shrink-0"
+            style={{ background: theme.primary, color: '#fff' }}
+          >
+            BTN
+          </div>
+        </div>
+      </div>
+      {/* Theme name + active checkmark */}
+      <div className="text-xs font-medium flex items-center justify-between gap-1">
+        <span className="truncate">{theme.name}</span>
+        {isActive && <span className="text-primary text-sm leading-none">✓</span>}
+      </div>
+    </button>
+  )
+}
 
 const SettingsModal = ({ isOpen, onClose }) => {
   const { settings, updateSettings, resetSettings, exportSettings } = useSettings()
@@ -20,18 +99,81 @@ const SettingsModal = ({ isOpen, onClose }) => {
     }
   }, [isOpen])
 
-  // Update pending changes for a specific setting
+  // Visual/cosmetic settings auto-apply instantly for live feedback (matches
+  // modern apps like Linear, Notion). Data/operational settings still require
+  // explicit Save & Apply because they trigger backend work or affect cost.
+  const AUTO_APPLY_KEYS = new Set([
+    'colorTheme',
+    'themeMode',
+    'fontFamily',
+    'fontSize',
+    'density',
+    'borderRadius',
+    'enableAnimations',
+    'codeTheme',
+    'conversationView',
+    'showTimestamps',
+    'showToolIcons',
+    'messageGrouping',
+    'markdownPreview',
+    'highlightColor',
+  ])
+
+  // Update value:
+  //   - Visual key → apply instantly via updateSettings (no Save button needed)
+  //   - Data key   → stash in pendingChanges, require explicit Save & Apply
   const handleChange = (key, value) => {
-    setPendingChanges(prev => ({
-      ...prev,
-      [key]: value
-    }))
-    setHasUnsavedChanges(true)
+    if (AUTO_APPLY_KEYS.has(key)) {
+      updateSettings({ [key]: value })
+      // Clean any stale pending entry for this key (in case it was set earlier
+      // when the key wasn't in AUTO_APPLY_KEYS)
+      if (pendingChanges.hasOwnProperty(key)) {
+        setPendingChanges(prev => {
+          const next = { ...prev }
+          delete next[key]
+          return next
+        })
+        if (Object.keys(pendingChanges).length === 1) setHasUnsavedChanges(false)
+      }
+    } else {
+      setPendingChanges(prev => ({ ...prev, [key]: value }))
+      setHasUnsavedChanges(true)
+    }
   }
 
   // Get current value (pending or saved)
   const getValue = (key) => {
     return pendingChanges.hasOwnProperty(key) ? pendingChanges[key] : settings[key]
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Theme hover state — local only, drives the preview block animation
+  // (no global CSS swap; the preview lives entirely inside each card).
+  // ─────────────────────────────────────────────────────────────────
+  const [hoveredTheme, setHoveredTheme] = useState(null)
+
+  // ─────────────────────────────────────────────────────────────────
+  // Randomize ALL visual settings at once.
+  // Picks a different value than current for each randomizable key.
+  // ─────────────────────────────────────────────────────────────────
+  const pickDifferent = (current, options) => {
+    if (!options || options.length <= 1) return current
+    let pick = current
+    let attempts = 0
+    while (pick === current && attempts < 20) {
+      pick = options[Math.floor(Math.random() * options.length)]
+      attempts++
+    }
+    return pick
+  }
+
+  const handleRandomize = () => {
+    const changes = {}
+    for (const [key, options] of Object.entries(RANDOMIZABLE_OPTIONS)) {
+      changes[key] = pickDifferent(getValue(key), options)
+    }
+    // All RANDOMIZABLE_OPTIONS keys are visual → apply instantly
+    updateSettings(changes)
   }
 
   // Save changes for current section
@@ -70,23 +212,25 @@ const SettingsModal = ({ isOpen, onClose }) => {
 
   return (
     <>
-      {/* Settings Modal */}
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-[hsl(var(--surface))] rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+      {/* Settings Modal — full-screen on mobile, dialog on desktop */}
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50 sm:p-4">
+        <div className="bg-[hsl(var(--surface))] sm:rounded-lg rounded-t-lg shadow-xl w-full max-w-3xl h-[95vh] sm:max-h-[90vh] sm:h-auto overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
           <h2 className="text-xl font-bold text-[hsl(var(--text-primary))]">Settings</h2>
           <button
             onClick={onClose}
-            className="text-text-tertiary hover:text-text-primary transition-colors"
+            aria-label="Close settings"
+            title="Close settings"
+            className="text-text-tertiary hover:text-text-primary transition-colors p-1 rounded focus:outline-none focus:ring-2 focus:ring-primary"
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 
-        <div className="flex flex-1 overflow-hidden">
-          {/* Sidebar Tabs */}
-          <div className="w-48 border-r border-border bg-surface p-2">
+        <div className="flex flex-col sm:flex-row flex-1 overflow-hidden">
+          {/* Sidebar Tabs — horizontal scroll on mobile, vertical sidebar on desktop */}
+          <div className="w-full sm:w-48 border-b sm:border-b-0 sm:border-r border-border bg-surface p-2 flex sm:block overflow-x-auto sm:overflow-x-visible flex-shrink-0">
             {tabs.map(tab => {
               const Icon = tab.icon
               return (
@@ -94,7 +238,9 @@ const SettingsModal = ({ isOpen, onClose }) => {
                   key={tab.id}
                   onClick={() => tab.available && setActiveTab(tab.id)}
                   disabled={!tab.available}
-                  className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors mb-1 relative ${
+                  aria-label={`${tab.label} settings${!tab.available ? ' (coming soon)' : ''}`}
+                  aria-current={activeTab === tab.id ? 'page' : undefined}
+                  className={`flex-shrink-0 sm:w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors mb-0 sm:mb-1 mr-1 sm:mr-0 relative whitespace-nowrap ${
                     activeTab === tab.id
                       ? 'bg-primary text-white'
                       : tab.available
@@ -102,8 +248,8 @@ const SettingsModal = ({ isOpen, onClose }) => {
                       : 'text-text-tertiary opacity-50 cursor-not-allowed'
                   }`}
                 >
-                  <Icon className="w-4 h-4" />
-                  <span className="flex-1 text-left">{tab.label}</span>
+                  <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                  <span className="text-left">{tab.label}</span>
                   {!tab.available && (
                     <span className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--border))] text-text-tertiary">
                       Soon
@@ -121,142 +267,40 @@ const SettingsModal = ({ isOpen, onClose }) => {
                 <div>
                   <h3 className="text-lg font-semibold text-text-primary mb-4">Appearance Settings</h3>
 
-                  {/* Color Theme Selector */}
+                  {/* Color Theme Selector — preview block + Randomize all */}
                   <div className="mb-6">
-                    <label className="block text-sm font-medium text-text-primary mb-2">
-                      Color Theme
-                    </label>
-                    <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
-                      {/* Default Theme */}
+                    <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+                      <label className="block text-sm font-medium text-text-primary">
+                        Color Theme
+                        <span className="ml-2 text-xs text-text-tertiary font-normal">
+                          (each card shows a live preview)
+                        </span>
+                      </label>
                       <button
-                        onClick={() => handleChange('colorTheme', 'default')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'default'
-                            ? 'border-slate-700 bg-slate-50'
-                            : 'border-border hover:border-slate-400'
-                        }`}
+                        type="button"
+                        onClick={handleRandomize}
+                        title="Randomize ALL visual settings — theme, font, size, density, radius, view"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-white bg-gradient-to-r from-primary to-primary-dark rounded-md hover:shadow-md hover:scale-105 transition-all active:scale-95"
                       >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-slate-700 to-slate-500 mb-1"></div>
-                        <div className="text-xs font-medium">Default</div>
-                      </button>
-
-                      {/* Emerald Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'emerald')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'emerald'
-                            ? 'border-[#10b981] bg-[#ecfdf5]'
-                            : 'border-border hover:border-[#6ee7b7]'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-[#10b981] to-[#34d399] mb-1"></div>
-                        <div className="text-xs font-medium">Emerald</div>
-                      </button>
-
-                      {/* Green Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'green')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'green'
-                            ? 'border-green-600 bg-green-50'
-                            : 'border-border hover:border-green-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-green-600 to-green-400 mb-1"></div>
-                        <div className="text-xs font-medium">Green</div>
-                      </button>
-
-                      {/* Blue Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'blue')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'blue'
-                            ? 'border-blue-600 bg-blue-50'
-                            : 'border-border hover:border-blue-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-blue-600 to-blue-400 mb-1"></div>
-                        <div className="text-xs font-medium">Blue</div>
-                      </button>
-
-                      {/* Purple Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'purple')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'purple'
-                            ? 'border-purple-600 bg-purple-50'
-                            : 'border-border hover:border-purple-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-purple-600 to-violet-400 mb-1"></div>
-                        <div className="text-xs font-medium">Purple</div>
-                      </button>
-
-                      {/* Orange Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'orange')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'orange'
-                            ? 'border-orange-500 bg-orange-50'
-                            : 'border-border hover:border-orange-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-orange-500 to-orange-400 mb-1"></div>
-                        <div className="text-xs font-medium">Orange</div>
-                      </button>
-
-                      {/* Red Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'red')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'red'
-                            ? 'border-red-500 bg-red-50'
-                            : 'border-border hover:border-red-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-red-500 to-red-400 mb-1"></div>
-                        <div className="text-xs font-medium">Red</div>
-                      </button>
-
-                      {/* Rose Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'rose')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'rose'
-                            ? 'border-rose-400 bg-rose-50'
-                            : 'border-border hover:border-rose-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-rose-400 to-rose-300 mb-1"></div>
-                        <div className="text-xs font-medium">Rose</div>
-                      </button>
-
-                      {/* Yellow Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'yellow')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'yellow'
-                            ? 'border-yellow-500 bg-yellow-50'
-                            : 'border-border hover:border-yellow-300'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-yellow-500 to-yellow-400 mb-1"></div>
-                        <div className="text-xs font-medium">Yellow</div>
-                      </button>
-
-                      {/* Classic Theme */}
-                      <button
-                        onClick={() => handleChange('colorTheme', 'classic')}
-                        className={`p-2 rounded-md border-2 transition-all ${
-                          getValue('colorTheme') === 'classic'
-                            ? 'border-[#5B8DEF] bg-[#FCFCFD]'
-                            : 'border-border hover:border-[#9BB8F5]'
-                        }`}
-                      >
-                        <div className="w-full h-6 rounded bg-gradient-to-r from-[#5B8DEF] to-[#8AAEF2] mb-1"></div>
-                        <div className="text-xs font-medium">Classic</div>
+                        🎲 Surprise Me
                       </button>
                     </div>
+                    <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-2">
+                      {THEMES.map(theme => (
+                        <ThemePreviewCard
+                          key={theme.id}
+                          theme={theme}
+                          isActive={getValue('colorTheme') === theme.id}
+                          isHovered={hoveredTheme === theme.id}
+                          onClick={() => handleChange('colorTheme', theme.id)}
+                          onHover={() => setHoveredTheme(theme.id)}
+                          onLeave={() => setHoveredTheme(null)}
+                        />
+                      ))}
+                    </div>
+                    <p className="text-xs text-text-tertiary mt-2">
+                      ✨ Visual settings apply instantly. Data settings (search, sessions) require <span className="font-semibold">Save &amp; Apply</span>.
+                    </p>
                   </div>
 
                   {/* Theme Mode (Light/Dark) */}

--- a/client/src/components/TremorProjectView.jsx
+++ b/client/src/components/TremorProjectView.jsx
@@ -11,7 +11,8 @@ import {
   ChevronLeft,
   Activity
 } from 'lucide-react'
-import { projectsApi } from '../services/api'
+import { projectsApi, statsApi } from '../services/api'
+import { Skeleton, SkeletonText, LoadingScreen } from './ui/loading'
 import {
   Card,
   Title,
@@ -31,6 +32,58 @@ import SessionMetadataControls from './SessionMetadataControls'
 import ProjectExportButton from './ProjectExportButton'
 import '../styles/tremor-dashboard.scss'
 
+// Custom polished horizontal bar chart — replaces Tremor's BarList for a nicer look.
+// Features: rank badges, name above bar (no overlap), value on right, gradient fill, hover lift.
+function CustomBarChart({ title, data, dotColor, barColorClass, badgeClass }) {
+  const total = data.reduce((sum, d) => sum + d.value, 0)
+  const max = Math.max(...data.map(d => d.value), 1)
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <div className={`w-2 h-2 rounded-full ${dotColor}`} />
+          <Text className="font-semibold text-text-primary text-sm">{title}</Text>
+        </div>
+        <Badge size="xs" className={`${badgeClass} rounded font-medium`}>
+          Total: {total.toLocaleString()}
+        </Badge>
+      </div>
+      <div className="space-y-2.5">
+        {data.map((d, i) => {
+          const percentage = max > 0 ? (d.value / max) * 100 : 0
+          const shareOfTotal = total > 0 ? ((d.value / total) * 100).toFixed(1) : '0'
+          return (
+            <div key={d.name} className="group">
+              <div className="flex items-center justify-between mb-1 gap-2">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <span className="text-xs font-medium text-text-tertiary tabular-nums w-4 flex-shrink-0">
+                    {i + 1}
+                  </span>
+                  <span className="text-sm font-medium text-text-primary truncate" title={d.name}>
+                    {d.name}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className="text-xs text-text-tertiary tabular-nums">{shareOfTotal}%</span>
+                  <span className="text-sm font-bold text-text-primary tabular-nums min-w-[60px] text-right">
+                    {d.value.toLocaleString()}
+                  </span>
+                </div>
+              </div>
+              <div className="relative h-2 bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
+                <div
+                  className={`h-full bg-gradient-to-r ${barColorClass} rounded-full transition-all duration-700 ease-out group-hover:brightness-110`}
+                  style={{ width: `${percentage}%` }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 const TremorProjectView = () => {
   const { projectId, sessionId } = useParams()
   const [searchParams] = useSearchParams()
@@ -46,9 +99,16 @@ const TremorProjectView = () => {
   }
 
   // Get all projects data for dashboard overview
-  const { data: projectsData } = useQuery({
+  const { data: projectsData, isLoading: projectsLoading } = useQuery({
     queryKey: ['projects'],
     queryFn: () => projectsApi.getProjects().then(res => res.data)
+  })
+
+  // REAL message-role distribution from FTS5 (replaces fake 44/47/9 hardcoded percentages)
+  const { data: roleStats, isLoading: roleStatsLoading } = useQuery({
+    queryKey: ['stats', 'message-roles'],
+    queryFn: () => statsApi.getMessageRoles().then(res => res.data),
+    staleTime: 60_000, // refresh every minute
   })
 
   // Get sessions data
@@ -138,7 +198,11 @@ const TremorProjectView = () => {
                 <Flex alignItems="start" justifyContent="between">
                   <div>
                     <Text className="text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Projects</Text>
-                    <Metric className="tremor-metric-sm mt-2">{totalProjectsCount}</Metric>
+                    {projectsLoading ? (
+                      <Skeleton className="h-9 w-16 mt-2" />
+                    ) : (
+                      <Metric className="tremor-metric-sm mt-2">{totalProjectsCount.toLocaleString()}</Metric>
+                    )}
                   </div>
                   <div className="p-3 bg-primary/10 rounded-lg">
                     <Folder className="w-6 h-6 text-primary" />
@@ -155,7 +219,11 @@ const TremorProjectView = () => {
                 <Flex alignItems="start" justifyContent="between">
                   <div>
                     <Text className="text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Sessions</Text>
-                    <Metric className="tremor-metric-sm mt-2">{totalSessionsCount.toLocaleString()}</Metric>
+                    {projectsLoading ? (
+                      <Skeleton className="h-9 w-20 mt-2" />
+                    ) : (
+                      <Metric className="tremor-metric-sm mt-2">{totalSessionsCount.toLocaleString()}</Metric>
+                    )}
                   </div>
                   <div className="p-3 bg-success/10 rounded-lg">
                     <MessageSquare className="w-6 h-6 text-success" />
@@ -172,9 +240,13 @@ const TremorProjectView = () => {
                 <Flex alignItems="start" justifyContent="between">
                   <div>
                     <Text className="text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Messages</Text>
-                    <Metric className="tremor-metric-sm mt-2">
-                      {totalMessagesCount > 1000 ? `${(totalMessagesCount / 1000).toFixed(1)}K` : totalMessagesCount}
-                    </Metric>
+                    {projectsLoading ? (
+                      <Skeleton className="h-9 w-24 mt-2" />
+                    ) : (
+                      <Metric className="tremor-metric-sm mt-2">
+                        {totalMessagesCount > 1000 ? `${(totalMessagesCount / 1000).toFixed(1)}K` : totalMessagesCount.toLocaleString()}
+                      </Metric>
+                    )}
                   </div>
                   <div className="p-3 bg-accent/10 rounded-lg">
                     <MessageSquare className="w-6 h-6 text-accent" />
@@ -191,7 +263,11 @@ const TremorProjectView = () => {
                 <Flex alignItems="start" justifyContent="between">
                   <div>
                     <Text className="text-xs font-semibold uppercase tracking-wider text-text-secondary">Active Today</Text>
-                    <Metric className="tremor-metric-sm mt-2">{activeTodayCount}</Metric>
+                    {projectsLoading ? (
+                      <Skeleton className="h-9 w-12 mt-2" />
+                    ) : (
+                      <Metric className="tremor-metric-sm mt-2">{activeTodayCount.toLocaleString()}</Metric>
+                    )}
                   </div>
                   <div className="p-3 bg-warning/10 rounded-lg">
                     <Zap className="w-6 h-6 text-warning" />
@@ -208,93 +284,130 @@ const TremorProjectView = () => {
             {/* Charts Section - Enterprise Design */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
               <Card className="tremor-card hover:shadow-xl transition-shadow duration-300">
-                <div className="mb-6 flex items-center justify-between">
+                <div className="mb-4 flex items-start justify-between">
                   <div>
                     <Title className="text-lg font-bold">Message Distribution</Title>
-                    <Text className="text-sm">Breakdown by conversation role</Text>
+                    <Text className="text-sm text-text-secondary">Real role breakdown from your FTS5 index</Text>
                   </div>
-                  <Badge size="sm" className="bg-blue-500/10 text-blue-600 rounded">Live</Badge>
+                  <Badge size="sm" className="bg-success/10 text-success rounded font-medium" icon={Activity}>
+                    {roleStats?.total ? `${roleStats.total.toLocaleString()} indexed` : 'Live'}
+                  </Badge>
                 </div>
-                <div className="tremor-chart">
-                  <DonutChart
-                    data={[
-                      { name: 'User Messages', value: Math.floor(totalMessagesCount * 0.44) },
-                      { name: 'Assistant Messages', value: Math.floor(totalMessagesCount * 0.47) },
-                      { name: 'System Messages', value: Math.floor(totalMessagesCount * 0.09) }
-                    ]}
-                    category="value"
-                    index="name"
-                    colors={['blue', 'emerald', 'slate']}
-                    className="h-48"
-                    showLabel={true}
-                    showAnimation={true}
-                    variant="donut"
-                  />
+                <div className="tremor-chart relative">
+                  {roleStatsLoading ? (
+                    <div className="h-48 flex items-center justify-center">
+                      <Skeleton className="h-40 w-40 rounded-full" />
+                    </div>
+                  ) : (
+                    <>
+                      <DonutChart
+                        data={[
+                          { name: 'User', value: roleStats?.byRole?.user || 0 },
+                          { name: 'Assistant', value: roleStats?.byRole?.assistant || 0 },
+                          { name: 'System', value: roleStats?.byRole?.system || 0 },
+                          ...(roleStats?.byRole?.tool ? [{ name: 'Tool', value: roleStats.byRole.tool }] : []),
+                        ]}
+                        category="value"
+                        index="name"
+                        colors={['blue', 'emerald', 'slate', 'amber']}
+                        className="h-48"
+                        showLabel={false}
+                        showAnimation={true}
+                        variant="donut"
+                        valueFormatter={(v) => v.toLocaleString()}
+                      />
+                      {/* Custom centered total — replaces showLabel which was unformatted */}
+                      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                        <Text className="text-xs text-text-secondary uppercase tracking-wider">Total</Text>
+                        <Metric className="text-2xl font-bold tracking-tight">
+                          {(roleStats?.total || 0).toLocaleString()}
+                        </Metric>
+                      </div>
+                    </>
+                  )}
                 </div>
                 <div className="mt-4 grid grid-cols-3 gap-4 pt-4 border-t border-border">
                   <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 mb-1">
-                      <div className="w-3 h-3 rounded-full" style={{backgroundColor: '#3b82f6'}}></div>
-                      <Text className="text-xs text-text-secondary">User</Text>
+                    <div className="flex items-center justify-center gap-1.5 mb-1">
+                      <div className="w-2.5 h-2.5 rounded-full bg-blue-500" />
+                      <Text className="text-xs font-medium text-text-secondary uppercase tracking-wide">User</Text>
                     </div>
-                    <Metric className="text-lg text-primary">{Math.floor(totalMessagesCount * 0.44).toLocaleString()}</Metric>
+                    <Metric className="text-lg font-bold text-blue-600">
+                      {(roleStats?.byRole?.user || 0).toLocaleString()}
+                    </Metric>
+                    {roleStats?.percentages?.user != null && (
+                      <Text className="text-xs text-text-tertiary">{roleStats.percentages.user}%</Text>
+                    )}
                   </div>
                   <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 mb-1">
-                      <div className="w-3 h-3 rounded-full" style={{backgroundColor: '#10b981'}}></div>
-                      <Text className="text-xs text-text-secondary">Assistant</Text>
+                    <div className="flex items-center justify-center gap-1.5 mb-1">
+                      <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
+                      <Text className="text-xs font-medium text-text-secondary uppercase tracking-wide">Assistant</Text>
                     </div>
-                    <Metric className="text-lg text-success">{Math.floor(totalMessagesCount * 0.47).toLocaleString()}</Metric>
+                    <Metric className="text-lg font-bold text-emerald-600">
+                      {(roleStats?.byRole?.assistant || 0).toLocaleString()}
+                    </Metric>
+                    {roleStats?.percentages?.assistant != null && (
+                      <Text className="text-xs text-text-tertiary">{roleStats.percentages.assistant}%</Text>
+                    )}
                   </div>
                   <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 mb-1">
-                      <div className="w-3 h-3 rounded-full" style={{backgroundColor: '#64748b'}}></div>
-                      <Text className="text-xs text-text-secondary">System</Text>
+                    <div className="flex items-center justify-center gap-1.5 mb-1">
+                      <div className="w-2.5 h-2.5 rounded-full bg-slate-500" />
+                      <Text className="text-xs font-medium text-text-secondary uppercase tracking-wide">System</Text>
                     </div>
-                    <Metric className="text-lg text-text-secondary">{Math.floor(totalMessagesCount * 0.09).toLocaleString()}</Metric>
+                    <Metric className="text-lg font-bold text-slate-600">
+                      {(roleStats?.byRole?.system || 0).toLocaleString()}
+                    </Metric>
+                    {roleStats?.percentages?.system != null && (
+                      <Text className="text-xs text-text-tertiary">{roleStats.percentages.system}%</Text>
+                    )}
                   </div>
                 </div>
               </Card>
 
               <Card className="tremor-card hover:shadow-xl transition-shadow duration-300">
-                <div className="mb-6 flex items-center justify-between">
+                <div className="mb-4 flex items-start justify-between">
                   <div>
                     <Title className="text-lg font-bold">Project Activity</Title>
-                    <Text className="text-sm">Top 5 projects by engagement</Text>
+                    <Text className="text-sm text-text-secondary">Top 5 projects by sessions and messages</Text>
                   </div>
-                  <Badge size="sm" className="bg-[hsl(var(--primary-light))]0/10 text-[hsl(var(--primary))] rounded">Updated</Badge>
+                  <Badge size="sm" className="bg-primary/10 text-primary rounded font-medium">
+                    {allProjects.length} {allProjects.length === 1 ? 'project' : 'projects'}
+                  </Badge>
                 </div>
-                {projectActivityData.length > 0 ? (
-                  <div className="space-y-6">
-                    {/* Sessions Chart */}
-                    <div>
-                      <div className="flex items-center justify-between mb-3">
-                        <Text className="font-semibold text-[hsl(var(--text-primary))]">Sessions by Project</Text>
-                        <Badge size="xs" className="bg-blue-500/10 text-blue-600 rounded">Total: {projectActivityData.reduce((sum, p) => sum + p.sessions, 0)}</Badge>
-                      </div>
-                      <BarList
-                        data={projectActivityData.map(p => ({
-                          name: p.project,
-                          value: p.sessions
-                        }))}
-                        color="blue"
-                        showAnimation={true}
-                      />
+                {projectsLoading ? (
+                  <div className="space-y-5">
+                    <div className="space-y-2">
+                      {[1,2,3,4,5].map(i => (
+                        <Skeleton key={`s-${i}`} className="h-9 w-full" />
+                      ))}
                     </div>
+                    <div className="pt-4 border-t border-border space-y-2">
+                      {[1,2,3,4,5].map(i => (
+                        <Skeleton key={`m-${i}`} className="h-9 w-full" />
+                      ))}
+                    </div>
+                  </div>
+                ) : projectActivityData.length > 0 ? (
+                  <div className="space-y-5">
+                    {/* Sessions Chart */}
+                    <CustomBarChart
+                      title="Sessions by Project"
+                      dotColor="bg-blue-500"
+                      barColorClass="from-blue-500 to-blue-600"
+                      badgeClass="bg-blue-500/10 text-blue-600"
+                      data={projectActivityData.map(p => ({ name: p.project, value: p.sessions }))}
+                    />
 
                     {/* Messages Chart */}
                     <div className="pt-4 border-t border-border">
-                      <div className="flex items-center justify-between mb-3">
-                        <Text className="font-semibold text-[hsl(var(--text-primary))]">Messages by Project</Text>
-                        <Badge size="xs" className="bg-[hsl(var(--primary-light))]0/10 text-[hsl(var(--primary))] rounded">Total: {projectActivityData.reduce((sum, p) => sum + p.messages, 0).toLocaleString()}</Badge>
-                      </div>
-                      <BarList
-                        data={projectActivityData.map(p => ({
-                          name: p.project,
-                          value: p.messages
-                        }))}
-                        color="emerald"
-                        showAnimation={true}
+                      <CustomBarChart
+                        title="Messages by Project"
+                        dotColor="bg-emerald-500"
+                        barColorClass="from-emerald-500 to-emerald-600"
+                        badgeClass="bg-emerald-500/10 text-emerald-600"
+                        data={projectActivityData.map(p => ({ name: p.project, value: p.messages }))}
                       />
                     </div>
                   </div>
@@ -316,15 +429,42 @@ const TremorProjectView = () => {
                   <Title className="text-xl font-bold">All Projects</Title>
                   <Text className="text-sm">Select a project to view detailed analytics</Text>
                 </div>
-                <Badge size="lg" className="bg-indigo-500/10 text-indigo-600 rounded">
-                  {allProjects.length} Total
-                </Badge>
+                {projectsLoading ? (
+                  <Skeleton className="h-7 w-20 rounded-md" />
+                ) : (
+                  <Badge size="lg" className="bg-indigo-500/10 text-indigo-600 rounded">
+                    {allProjects.length} Total
+                  </Badge>
+                )}
               </div>
-              {allProjects.length === 0 ? (
+              {projectsLoading ? (
+                <div className="space-y-2">
+                  {[1,2,3,4,5,6].map(i => (
+                    <div key={i} className="flex items-center gap-4 p-4 border border-border rounded-lg">
+                      <Skeleton className="w-10 h-10 rounded-lg flex-shrink-0" />
+                      <div className="flex-1 space-y-1.5 min-w-0">
+                        <Skeleton className="h-4 w-2/5" />
+                        <Skeleton className="h-3 w-3/5" />
+                      </div>
+                      <Skeleton className="h-6 w-16 rounded-full flex-shrink-0" />
+                    </div>
+                  ))}
+                </div>
+              ) : allProjects.length === 0 ? (
                 <div className="text-center py-12 bg-surface rounded-lg">
                   <Folder className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
                   <Title className="text-text-secondary mb-2">No Projects Found</Title>
-                  <Text className="text-text-secondary">Start using Claude Code to create conversation projects</Text>
+                  <Text className="text-text-secondary mb-4 max-w-md mx-auto">
+                    Claudex looks for conversations in <code className="px-1.5 py-0.5 bg-zinc-100 dark:bg-zinc-800 rounded text-xs font-mono">~/.claude/projects/</code>. Start a session in Claude Code to create your first project.
+                  </Text>
+                  <a
+                    href="https://docs.claude.com/en/docs/claude-code/quickstart"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-primary border border-primary/30 rounded-md hover:bg-primary/5 transition-colors"
+                  >
+                    📖 Claude Code Quickstart
+                  </a>
                 </div>
               ) : (
                 <>

--- a/client/src/components/ui/loading.jsx
+++ b/client/src/components/ui/loading.jsx
@@ -1,0 +1,313 @@
+import React from 'react'
+import { Loader2 } from 'lucide-react'
+import { useIsFetching, useIsMutating } from '@tanstack/react-query'
+import { cn } from '@/lib/utils'
+
+/**
+ * Loading Component Library — single source of truth for loading UX
+ *
+ * Variants:
+ *   <Spinner />            — small inline spinner (icon)
+ *   <LoadingScreen />      — full panel: centered spinner + optional label
+ *   <Skeleton />           — single shimmer placeholder
+ *   <SkeletonText />       — multi-line text shimmer
+ *   <SkeletonCard />       — card-shaped shimmer
+ *   <TableLoadingRows />   — N skeleton rows for tables
+ *   <CardLoadingGrid />    — N skeleton cards in a grid
+ *   <ListLoadingItems />   — N skeleton list rows (with avatar/title/subtitle)
+ *   <ModalLoadingContent /> — content area for loading modals
+ *
+ * Use:
+ *   if (isLoading) return <LoadingScreen label="Loading sessions..." />
+ *   {isLoading ? <TableLoadingRows count={5} /> : <Table data={data} />}
+ */
+
+// ─────────────────────────────────────────────────────────────────────
+// Spinner — minimal inline spinner (icon-only)
+// ─────────────────────────────────────────────────────────────────────
+export function Spinner({ size = 'default', className, ...props }) {
+  const sizeMap = {
+    xs: 'w-3 h-3',
+    sm: 'w-4 h-4',
+    default: 'w-5 h-5',
+    lg: 'w-6 h-6',
+    xl: 'w-8 h-8',
+  }
+  return (
+    <Loader2
+      className={cn('animate-spin text-primary', sizeMap[size] || sizeMap.default, className)}
+      {...props}
+    />
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// LoadingScreen — centered spinner + label, fills its container
+// ─────────────────────────────────────────────────────────────────────
+export function LoadingScreen({
+  label,
+  description,
+  size = 'xl',
+  fullScreen = false,
+  className,
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3',
+        fullScreen ? 'min-h-screen w-full' : 'h-full w-full py-12',
+        className
+      )}
+    >
+      <Spinner size={size} />
+      {label && (
+        <div className="text-sm font-medium text-foreground">{label}</div>
+      )}
+      {description && (
+        <div className="text-xs text-muted-foreground max-w-md text-center">
+          {description}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Skeleton — single shimmer block
+// Uses zinc tones for visibility across all 10 themes (--surface is often
+// pure white which renders the skeleton invisible against card bg).
+// ─────────────────────────────────────────────────────────────────────
+export function Skeleton({ className, ...props }) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-md bg-zinc-200/80 dark:bg-zinc-700/40',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// SkeletonText — multi-line shimmer (paragraph placeholder)
+// ─────────────────────────────────────────────────────────────────────
+export function SkeletonText({ lines = 3, className }) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className={cn(
+            'h-3.5',
+            i === lines - 1 ? 'w-4/6' : i % 2 === 0 ? 'w-full' : 'w-5/6'
+          )}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// SkeletonCard — card-shaped placeholder with title + body
+// ─────────────────────────────────────────────────────────────────────
+export function SkeletonCard({ className, hasImage = false }) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card p-4 space-y-3',
+        className
+      )}
+    >
+      {hasImage && <Skeleton className="h-32 w-full rounded-md" />}
+      <Skeleton className="h-5 w-2/3" />
+      <SkeletonText lines={2} />
+      <div className="flex gap-2 pt-1">
+        <Skeleton className="h-6 w-16 rounded-full" />
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// TableLoadingRows — N skeleton rows, useful inside <tbody>
+// ─────────────────────────────────────────────────────────────────────
+export function TableLoadingRows({ count = 5, columns = 5, className }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, rowIdx) => (
+        <tr key={rowIdx} className={cn('border-b border-border', className)}>
+          {Array.from({ length: columns }).map((_, colIdx) => (
+            <td key={colIdx} className="px-4 py-3">
+              <Skeleton
+                className={cn(
+                  'h-4',
+                  colIdx === 0 ? 'w-3/4' : colIdx === columns - 1 ? 'w-12' : 'w-2/3'
+                )}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// CardLoadingGrid — grid of N skeleton cards
+// ─────────────────────────────────────────────────────────────────────
+export function CardLoadingGrid({ count = 6, columns = 3, className }) {
+  const gridCols = {
+    1: 'grid-cols-1',
+    2: 'grid-cols-1 md:grid-cols-2',
+    3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+    4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+  }
+  return (
+    <div className={cn('grid gap-4', gridCols[columns] || gridCols[3], className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// ListLoadingItems — N skeleton list rows (avatar + title + subtitle)
+// ─────────────────────────────────────────────────────────────────────
+export function ListLoadingItems({ count = 5, hasIcon = true, className }) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 rounded-lg border border-border bg-card p-3"
+        >
+          {hasIcon && <Skeleton className="h-10 w-10 rounded-full flex-shrink-0" />}
+          <div className="flex-1 space-y-1.5 min-w-0">
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-6 w-16 rounded-full flex-shrink-0" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// ModalLoadingContent — purpose-built for modal bodies (like SessionSummaryModal)
+// ─────────────────────────────────────────────────────────────────────
+export function ModalLoadingContent({ label = 'Loading...', className }) {
+  return (
+    <div className={cn('space-y-5 py-2', className)}>
+      <div className="flex items-center justify-center gap-2 pb-2">
+        <Spinner size="sm" />
+        <span className="text-sm text-muted-foreground">{label}</span>
+      </div>
+      {/* Card 1 placeholder */}
+      <div className="rounded-lg border border-primary/20 overflow-hidden">
+        <div className="bg-primary/5 px-4 py-3 flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="p-4">
+          <SkeletonText lines={3} />
+        </div>
+      </div>
+      {/* Card 2 placeholder */}
+      <div className="rounded-lg border border-border overflow-hidden">
+        <div className="bg-surface px-4 py-3 flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+        <div className="p-4 space-y-3">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-4 w-4/5" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// TopProgressBar — global indeterminate progress bar at top of viewport
+// Activates when any TanStack Query is fetching or any mutation is running.
+// Drop into App root once; auto-shows during all data activity.
+// ─────────────────────────────────────────────────────────────────────
+export function TopProgressBar({ className }) {
+  const isFetching = useIsFetching()
+  const isMutating = useIsMutating()
+  const active = isFetching > 0 || isMutating > 0
+
+  // Slight delay before showing to avoid flicker on fast queries
+  const [visible, setVisible] = React.useState(false)
+  React.useEffect(() => {
+    let t
+    if (active) {
+      t = setTimeout(() => setVisible(true), 150) // only show if > 150ms
+    } else {
+      setVisible(false)
+    }
+    return () => clearTimeout(t)
+  }, [active])
+
+  return (
+    <div
+      className={cn(
+        'fixed top-0 left-0 right-0 h-0.5 z-[9999] overflow-hidden pointer-events-none',
+        'transition-opacity duration-200',
+        visible ? 'opacity-100' : 'opacity-0',
+        className
+      )}
+      role="progressbar"
+      aria-label={active ? 'Loading' : ''}
+      aria-busy={active}
+    >
+      {/* Animated indeterminate bar — shimmer movement across the full width */}
+      <div className="h-full w-full bg-primary/10">
+        <div className="h-full w-1/3 bg-primary animate-[loadingbar_1.4s_ease-in-out_infinite]" />
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// InlineProgressBar — indeterminate bar that fits inside a container
+// Use for in-component loading (modal headers, panel tops, etc).
+// ─────────────────────────────────────────────────────────────────────
+export function InlineProgressBar({ active = true, className }) {
+  if (!active) return null
+  return (
+    <div
+      className={cn(
+        'h-0.5 w-full overflow-hidden bg-primary/10 rounded-full',
+        className
+      )}
+      role="progressbar"
+      aria-label="Loading"
+      aria-busy={active}
+    >
+      <div className="h-full w-1/3 bg-primary animate-[loadingbar_1.4s_ease-in-out_infinite]" />
+    </div>
+  )
+}
+
+// Default export bundle — convenient for `import Loading from '@/components/ui/loading'`
+const Loading = {
+  Spinner,
+  Screen: LoadingScreen,
+  Skeleton,
+  Text: SkeletonText,
+  Card: SkeletonCard,
+  TableRows: TableLoadingRows,
+  CardGrid: CardLoadingGrid,
+  ListItems: ListLoadingItems,
+  ModalContent: ModalLoadingContent,
+  TopBar: TopProgressBar,
+  InlineBar: InlineProgressBar,
+}
+
+export default Loading

--- a/client/src/contexts/ToastContext.jsx
+++ b/client/src/contexts/ToastContext.jsx
@@ -1,0 +1,154 @@
+import React, { createContext, useContext, useCallback, useState, useEffect } from 'react'
+import { CheckCircle2, XCircle, AlertTriangle, Info, X } from 'lucide-react'
+
+/**
+ * ToastContext — single source of truth for all transient notifications.
+ *
+ * Replaces the previous ad-hoc patterns:
+ *   - Footer.jsx: document.createElement('div') hacks
+ *   - App.jsx: prop-drilled <Toast> only used by 1 component
+ *   - SearchPage.jsx: copySuccess local state
+ *
+ * Usage:
+ *   const toast = useToast()
+ *   toast.success('Saved!')
+ *   toast.error('Network failed', { duration: 8000 })
+ *   toast.info('Indexing started', { action: { label: 'Cancel', onClick: () => abort() } })
+ *
+ * Features:
+ *   - Stacking (multiple toasts stack vertically)
+ *   - ARIA-correct (role=status for info/success, role=alert for error/warning)
+ *   - Manual dismiss + auto-dismiss
+ *   - Optional action button per toast
+ *   - Theme-aware (uses CSS variables)
+ *   - Animated in/out
+ */
+
+const ToastContext = createContext(null)
+
+let nextId = 0
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([])
+
+  const dismiss = useCallback((id) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const show = useCallback((message, options = {}) => {
+    const {
+      type = 'info',
+      duration = 4000,
+      action = null,
+      title = null,
+    } = options
+    const id = ++nextId
+    setToasts(prev => [...prev, { id, message, type, duration, action, title }])
+    if (duration > 0) {
+      setTimeout(() => dismiss(id), duration)
+    }
+    return id
+  }, [dismiss])
+
+  const api = {
+    show,
+    dismiss,
+    success: (message, options) => show(message, { ...options, type: 'success' }),
+    error:   (message, options) => show(message, { ...options, type: 'error', duration: options?.duration ?? 6000 }),
+    warning: (message, options) => show(message, { ...options, type: 'warning', duration: options?.duration ?? 5000 }),
+    info:    (message, options) => show(message, { ...options, type: 'info' }),
+  }
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within <ToastProvider>')
+  return ctx
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Toast UI components
+// ─────────────────────────────────────────────────────────────────────
+
+function ToastContainer({ toasts, onDismiss }) {
+  return (
+    <div
+      className="fixed top-4 right-4 z-[10000] flex flex-col gap-2 pointer-events-none max-w-[calc(100vw-2rem)]"
+      aria-live="polite"
+      aria-atomic="false"
+    >
+      {toasts.map(toast => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>
+  )
+}
+
+const TYPE_CONFIG = {
+  success: { Icon: CheckCircle2, bg: 'bg-success', text: 'text-white',  iconColor: 'text-white',   role: 'status' },
+  error:   { Icon: XCircle,      bg: 'bg-error',   text: 'text-white',  iconColor: 'text-white',   role: 'alert'  },
+  warning: { Icon: AlertTriangle,bg: 'bg-warning', text: 'text-white',  iconColor: 'text-white',   role: 'alert'  },
+  info:    { Icon: Info,         bg: 'bg-primary', text: 'text-white',  iconColor: 'text-white',   role: 'status' },
+}
+
+function ToastItem({ toast, onDismiss }) {
+  const config = TYPE_CONFIG[toast.type] || TYPE_CONFIG.info
+  const { Icon } = config
+  const [exiting, setExiting] = useState(false)
+
+  // Animate in on mount
+  const [entered, setEntered] = useState(false)
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setEntered(true))
+    return () => cancelAnimationFrame(t)
+  }, [])
+
+  const handleDismiss = () => {
+    setExiting(true)
+    setTimeout(() => onDismiss(toast.id), 200)
+  }
+
+  return (
+    <div
+      role={config.role}
+      className={`pointer-events-auto flex items-start gap-3 rounded-lg shadow-lg ring-1 ring-black/10 px-4 py-3 min-w-[280px] max-w-md
+        ${config.bg} ${config.text}
+        transition-all duration-200 ease-out
+        ${entered && !exiting ? 'translate-x-0 opacity-100' : 'translate-x-4 opacity-0'}
+      `}
+    >
+      <Icon className={`w-5 h-5 ${config.iconColor} flex-shrink-0 mt-0.5`} aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        {toast.title && (
+          <div className="font-semibold text-sm mb-0.5">{toast.title}</div>
+        )}
+        <div className="text-sm leading-snug break-words">{toast.message}</div>
+        {toast.action && (
+          <button
+            onClick={() => {
+              toast.action.onClick?.()
+              handleDismiss()
+            }}
+            className="mt-2 px-2 py-1 text-xs font-semibold rounded bg-white/15 hover:bg-white/25 transition-colors"
+          >
+            {toast.action.label}
+          </button>
+        )}
+      </div>
+      <button
+        onClick={handleDismiss}
+        aria-label="Dismiss notification"
+        className="flex-shrink-0 -mr-1 -mt-1 p-1 rounded hover:bg-white/15 transition-colors"
+      >
+        <X className="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/client/src/hooks/useKeyboardShortcuts.js
+++ b/client/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,113 @@
+import { useEffect } from 'react'
+
+/**
+ * useKeyboardShortcuts — register global keyboard handlers.
+ *
+ * Standard shortcuts (matching modern apps like GitHub, Linear, Notion):
+ *
+ *   ?         → Show keyboard help overlay (callback: onShowHelp)
+ *   /         → Focus search input on the current page (callback: onFocusSearch)
+ *   Esc       → Close current modal/overlay (callback: onEscape)
+ *   Cmd+K     → Open command palette (callback: onCommandPalette)
+ *   Cmd+,     → Open settings (callback: onOpenSettings)
+ *   g then s  → Go to Search (callback: onGoSearch)
+ *   g then m  → Go to Manage (callback: onGoManage)
+ *   g then a  → Go to Analytics (callback: onGoAnalytics)
+ *
+ * Shortcuts are disabled while focus is in an input/textarea/contenteditable
+ * (so typing "/" in a textbox doesn't trigger the search shortcut).
+ * `Esc` is the only exception — it always works to close modals.
+ */
+export function useKeyboardShortcuts({
+  onShowHelp,
+  onFocusSearch,
+  onEscape,
+  onCommandPalette,
+  onOpenSettings,
+  onGoSearch,
+  onGoManage,
+  onGoAnalytics,
+  enabled = true,
+} = {}) {
+  useEffect(() => {
+    if (!enabled) return
+
+    let lastG = 0 // timestamp of last 'g' press for sequence shortcuts
+
+    const isTypingTarget = (target) => {
+      if (!target) return false
+      const tag = target.tagName?.toLowerCase()
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return true
+      if (target.isContentEditable) return true
+      return false
+    }
+
+    const handler = (e) => {
+      const typing = isTypingTarget(e.target)
+      const cmd = e.metaKey || e.ctrlKey
+
+      // Esc always works, even when typing
+      if (e.key === 'Escape') {
+        if (onEscape) {
+          onEscape()
+        }
+        return
+      }
+
+      if (typing) return
+
+      // Cmd+K — command palette
+      if (cmd && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        onCommandPalette?.()
+        return
+      }
+
+      // Cmd+, — settings
+      if (cmd && e.key === ',') {
+        e.preventDefault()
+        onOpenSettings?.()
+        return
+      }
+
+      // ? — help
+      if (e.key === '?') {
+        e.preventDefault()
+        onShowHelp?.()
+        return
+      }
+
+      // / — focus search
+      if (e.key === '/') {
+        e.preventDefault()
+        onFocusSearch?.()
+        return
+      }
+
+      // g + (s|m|a) — go-to navigation
+      if (e.key.toLowerCase() === 'g') {
+        lastG = Date.now()
+        return
+      }
+
+      // Within 800ms of pressing g, accept the second key
+      if (Date.now() - lastG < 800 && lastG > 0) {
+        const second = e.key.toLowerCase()
+        if (second === 's') {
+          e.preventDefault()
+          onGoSearch?.()
+        } else if (second === 'm') {
+          e.preventDefault()
+          onGoManage?.()
+        } else if (second === 'a') {
+          e.preventDefault()
+          onGoAnalytics?.()
+        }
+        lastG = 0
+      }
+    }
+
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [enabled, onShowHelp, onFocusSearch, onEscape, onCommandPalette, onOpenSettings, onGoSearch, onGoManage, onGoAnalytics])
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,6 +4,8 @@ import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.jsx'
 import { SettingsProvider } from './contexts/SettingsContext'
+import { ToastProvider } from './contexts/ToastContext'
+import ErrorBoundary from './components/ErrorBoundary'
 
 // Import design system (order matters!)
 import './styles/design-system.css'      // Base tokens
@@ -21,12 +23,16 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <SettingsProvider>
-        <QueryClientProvider client={queryClient}>
-          <App />
-        </QueryClientProvider>
-      </SettingsProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <SettingsProvider>
+          <QueryClientProvider client={queryClient}>
+            <ToastProvider>
+              <App />
+            </ToastProvider>
+          </QueryClientProvider>
+        </SettingsProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>,
 )

--- a/client/src/pages/SessionManagementPage.jsx
+++ b/client/src/pages/SessionManagementPage.jsx
@@ -11,6 +11,7 @@ import SessionSummaryModal from '../components/SessionSummaryModal'
 import { Card, CardContent } from '../components/ui/card'
 import { Badge } from '../components/ui/badge'
 import { H1, H2, P, Muted } from '../components/ui/typography'
+import { TableLoadingRows, LoadingScreen } from '../components/ui/loading'
 
 /**
  * SessionManagementPage - Dedicated page for managing sessions
@@ -205,10 +206,26 @@ const SessionManagementPage = () => {
       {/* Session Table */}
       <div className="flex-1 overflow-auto px-6 py-4">
         {isLoading ? (
-          <div className="flex items-center justify-center h-64">
-            <div className="text-center">
-              <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
-              <Muted>Loading sessions...</Muted>
+          <div className="rounded-lg border border-border bg-card overflow-hidden">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-border bg-surface text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="px-4 py-3 text-left w-10"></th>
+                  <th className="px-4 py-3 text-left">Session Title</th>
+                  <th className="px-4 py-3 text-left">Tags</th>
+                  <th className="px-4 py-3 text-left">Messages</th>
+                  <th className="px-4 py-3 text-left">Status</th>
+                  <th className="px-4 py-3 text-left">Last Updated</th>
+                  <th className="px-4 py-3 text-left w-12">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <TableLoadingRows count={8} columns={7} />
+              </tbody>
+            </table>
+            <div className="px-4 py-3 border-t border-border flex items-center justify-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              <span>Loading sessions...</span>
             </div>
           </div>
         ) : (

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -58,6 +58,11 @@ export const searchApi = {
   getIndexStatus: () => api.get('/search/index/status'),
 };
 
+export const statsApi = {
+  // Get real role distribution (user/assistant/system/tool) from FTS5 index
+  getMessageRoles: () => api.get('/stats/message-roles'),
+};
+
 export const sessionMetadataApi = {
   // Get session metadata (custom title, tags, notes, visibility)
   getMetadata: (projectId, sessionId) =>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -127,6 +127,17 @@ export default {
         slow: '300ms',
         slower: '500ms',
       },
+      // Custom keyframes for loading animations
+      keyframes: {
+        loadingbar: {
+          '0%': { transform: 'translateX(-100%)' },
+          '50%': { transform: 'translateX(150%)' },
+          '100%': { transform: 'translateX(400%)' },
+        },
+      },
+      animation: {
+        loadingbar: 'loadingbar 1.4s ease-in-out infinite',
+      },
     },
   },
   plugins: [

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -18,4 +18,26 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    // Increase chunk size warning threshold to 1MB so we don't get noisy warnings
+    // for legitimate large chunks like Tremor.
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        // Split large vendors into separate chunks for parallel loading + better caching.
+        // Tremor + recharts is ~700KB by itself; isolating it means the rest of the app
+        // loads faster and Tremor only loads when Analytics is visited.
+        manualChunks: {
+          // Charts/analytics — only needed on /tremor-preview
+          tremor: ['@tremor/react', 'recharts'],
+          // React + router core
+          react: ['react', 'react-dom', 'react-router-dom'],
+          // Data layer
+          query: ['@tanstack/react-query'],
+          // Markdown rendering — only when viewing conversations
+          markdown: ['react-markdown'],
+        },
+      },
+    },
+  },
 })

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,45 @@
 
 All notable changes to Claudex.
 
+## [1.3.3] - 2026-05-01
+
+### Added
+- **Official MCP Registry submission** — Claudex is now publishable to `registry.modelcontextprotocol.io` (Anthropic's official MCP registry). MCP clients (Claude Code, Cursor, Codex, Windsurf) can discover Claudex via the registry.
+- **`mcpName: io.github.kunwar-shah/claudex`** in package.json — required by the registry verification.
+- **`server.json` manifest** at the repo root — describes the package, transport (stdio), and optional env vars.
+
+### UI/UX (large polish pass)
+- **Auto-apply visual settings** — theme, font, font size, density, border radius, animations now apply instantly on click. No more "Save & Apply" button for visual changes.
+- **Theme preview block** in Settings — each card shows a mini mockup with the theme's primary color, surface, button, and badge. No more global CSS swap on hover.
+- **🎲 Surprise Me button** — randomizes ALL visual settings at once (theme, font, size, density, radius, view).
+- **Mobile-responsive Settings modal** — full-height bottom sheet on mobile, dialog on desktop. Tabs scroll horizontally on narrow screens.
+
+### Infrastructure
+- **Unified `<ToastProvider>` context** — replaces three different toast patterns (Footer DOM hacks, App.jsx prop drilling, SearchPage local state). Stacking, dismissable, ARIA-correct (`role="alert"` for errors, `role="status"` for info).
+- **`<ErrorBoundary>` at root** — catches all JS errors with a recovery UI (Try Again / Reload / Go Home / Report Issue with pre-filled GitHub link). Replaces white screen of death.
+- **Keyboard shortcuts** — `?` opens help overlay, `/` focuses search, `Esc` closes modals, `g s|m|a` jumps to Search/Manage/Analytics, `Cmd/Ctrl+K` reserved for command palette, `Cmd/Ctrl+,` opens settings.
+- **Bundle code-splitting** — initial JS bundle 10× smaller (442 KB → 46 KB gzipped). Routes lazy-loaded. Tremor (1 MB) only loads on Analytics page.
+- **ARIA labels** added to icon-only buttons in Settings, Header, SessionSummary, Export, ProjectExport.
+
+### Real Data
+- **Real role distribution chart** — Analytics dashboard now uses actual SQL `GROUP BY role` from FTS5 index instead of hardcoded 44/47/9% percentages. New `/api/stats/message-roles` endpoint.
+- **Honest "X indexed" badge** — replaces misleading "Live" tag.
+- **Custom polished bar chart** — replaces Tremor BarList. Rank numbers, share-of-total %, gradient fills, hover lift, formatted numbers.
+
+### Loading States
+- **`<TopProgressBar>`** — global indeterminate progress bar at top of viewport. Activates on any TanStack Query fetch or mutation. 150ms delay to avoid flicker.
+- **Skeleton placeholders** for: Manage Sessions table, ConversationThread, SessionList sidebar, SearchPage results, Tremor stat cards, All Projects list, donut chart.
+- New shared `<LoadingScreen>`, `<TableLoadingRows>`, `<CardLoadingGrid>`, `<ListLoadingItems>`, `<ModalLoadingContent>` components.
+
+### Fixed
+- **Export button 500 error** — session titles with em-dashes (—), quotes, or emoji corrupted the `Content-Disposition` HTTP header. Filename now sanitized to ASCII alphanumeric + dash + underscore.
+- **Per-page dropdown value cut off** — wider select with proper right padding for the dropdown arrow.
+- **Tags input "Add" button overflowing card** — added `min-w-0` on flex children so input can shrink below browser default min-width.
+- **Footer version label** — was stuck at "Claudex v1.2", now shows current version.
+- **Copy Context popup behind header** — z-index `z-50` → `z-[10000]`, position moved to clear sticky header.
+
+---
+
 ## [1.3.2] - 2026-04-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kunwarshah/claudex",
-  "version": "1.3.2",
+  "version": "1.3.3",
+  "mcpName": "io.github.kunwar-shah/claudex",
   "description": "Persistent memory + FTS5 search for Claude Code conversations. MCP server exposes your ~/.claude/projects/ history as queryable memory for any MCP-compatible AI agent.",
   "main": "index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kunwar-shah/claudex",
+  "description": "Persistent memory + FTS5 full-text search for Claude Code conversation history. Indexes ~/.claude/projects/ JSONL into SQLite, exposes 10 MCP tools (store/recall/search memories, browse sessions, get summaries) plus prompts. Includes a web UI for visual exploration.",
+  "repository": {
+    "url": "https://github.com/kunwar-shah/claudex",
+    "source": "github"
+  },
+  "version": "1.3.3",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@kunwarshah/claudex",
+      "version": "1.3.3",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PROJECT_ROOT",
+          "description": "Path to Claude Code conversation log directory. Defaults to ~/.claude/projects.",
+          "format": "string",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/server/src/routes/export.js
+++ b/server/src/routes/export.js
@@ -45,9 +45,22 @@ export async function exportRoutes(fastify, options) {
         projectName: project.name
       };
 
-      // Set appropriate headers based on format
+      // Sanitize filename for HTTP Content-Disposition header.
+      // Session titles can contain em-dashes (—), emoji, quotes, etc.
+      // which Node rejects in HTTP headers (ERR_INVALID_CHAR).
+      // Strip to ASCII alphanumeric + dash + underscore only.
       const timestamp = new Date().toISOString().split('T')[0];
-      const filename = `${project.name}-${session.title || sessionId}-${timestamp}`;
+      const safeProjectName = (project.name || 'project')
+        .replace(/[^a-zA-Z0-9-_]/g, '-')
+        .replace(/-+/g, '-')
+        .slice(0, 40)
+        .replace(/^-+|-+$/g, '');
+      const safeTitle = (session.title || sessionId)
+        .replace(/[^a-zA-Z0-9-_]/g, '-')
+        .replace(/-+/g, '-')
+        .slice(0, 40)
+        .replace(/^-+|-+$/g, '');
+      const filename = `${safeProjectName}-${safeTitle}-${timestamp}` || `claudex-export-${timestamp}`;
 
       switch (format.toLowerCase()) {
         case 'html':

--- a/server/src/routes/search.js
+++ b/server/src/routes/search.js
@@ -177,6 +177,41 @@ export async function searchRoutes(fastify, options) {
     }
   });
 
+  // GET /api/stats/message-roles
+  // Returns real counts of messages by role from the FTS5 index
+  fastify.get('/stats/message-roles', async (request, reply) => {
+    try {
+      const db = searchIndexer.searchDb.db
+      // Single GROUP BY query — fast on FTS5 with role column
+      const rows = await db.all(
+        `SELECT role, COUNT(*) AS count FROM messages_fts GROUP BY role`
+      ) || []
+      const roleStats = { user: 0, assistant: 0, system: 0, tool: 0, other: 0 }
+      let total = 0
+      for (const row of rows) {
+        const role = (row.role || '').toLowerCase()
+        const n = Number(row.count) || 0
+        if (role in roleStats) roleStats[role] += n
+        else roleStats.other += n
+        total += n
+      }
+      return {
+        total,
+        byRole: roleStats,
+        percentages: total > 0
+          ? Object.fromEntries(Object.entries(roleStats).map(([k, v]) => [k, Number(((v / total) * 100).toFixed(1))]))
+          : roleStats,
+        source: 'real',
+        timestamp: new Date().toISOString()
+      }
+    } catch (error) {
+      reply.code(500).send({
+        error: 'stats_failed',
+        message: error.message
+      })
+    }
+  });
+
   // GET /api/health
   fastify.get('/health', async (request, reply) => {
     try {


### PR DESCRIPTION
## Summary

Big release combining MCP Registry support + a substantial UX polish pass.

See `docs/changelog.md` for the complete itemized list.

## Highlights

- 📋 **Official MCP Registry** ready (mcpName + server.json)
- ✨ Visual settings auto-apply (no Save button)
- 🎨 Theme preview block (no global CSS swap)
- 🎲 Surprise Me — randomize all visual settings
- 📱 Mobile-responsive Settings modal
- 🔔 Unified ToastProvider
- 🛡️ ErrorBoundary
- ⌨️ Keyboard shortcuts (`?` for help)
- ⚡ 10× smaller initial JS bundle (code-splitting)
- 📊 Real role distribution chart (not fake 44/47/9%)
- 🐛 Fixed: Export 500, per-page cutoff, tags overflow, footer v1.2 → v1.3.3

## Test plan

- [ ] CI passes
- [ ] Hard-refresh `/` — site loads, shows TopProgressBar during fetch
- [ ] Open Settings → click theme → applies instantly
- [ ] Click 🎲 Surprise Me → all visual settings change
- [ ] Press `?` from anywhere → keyboard help opens
- [ ] Try Export → JSON/HTML/TXT all download (was 500 before)
- [ ] Resize to mobile width → Settings modal becomes full-height sheet
- [ ] /tremor-preview → real role distribution + polished bar charts