### PR TITLE
chore: shorten server.json description + add glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["kunwar-shah"]
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.kunwar-shah/claudex",
-  "description": "Persistent memory + FTS5 full-text search for Claude Code conversation history. Indexes ~/.claude/projects/ JSONL into SQLite, exposes 10 MCP tools (store/recall/search memories, browse sessions, get summaries) plus prompts. Includes a web UI for visual exploration.",
+  "description": "Persistent memory + FTS5 search MCP server for Claude Code conversation history.",
   "repository": {
     "url": "https://github.com/kunwar-shah/claudex",
     "source": "github"


### PR DESCRIPTION
## Summary

Two small fixes for the MCP Registry + Glama listings:

1. **server.json** — shorten description to 81 chars. The MCP Registry enforces `description <= 100` chars; the previous 295-char description failed registry validation with a 422.

2. **glama.json** — new file at repo root. Per Glama docs, this signals authorized maintainers and makes future re-claims easier. `maintainers: ["kunwar-shah"]`.

Full description (the longer one) still lives in package.json and README — those don't have the 100-char limit.