### PR TITLE
fix(server): bump sqlite3 to ^6.0.1 for Node 22 prebuilts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to Claudex.
 
+## [1.3.4] - 2026-05-03
+
+### Fixed
+- **sqlite3 native bindings on Node 22** — bumped `sqlite3` from `^5.1.6` to `^6.0.1`. The 5.x line lacks prebuilts for Node 22's ABI (NODE_MODULE_VERSION 127); v6.0.1 ships them. Fixes Glama validation failure and any `npm install -g @kunwarshah/claudex` on Node 22+.
+
+---
+
 ## [1.3.3] - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunwarshah/claudex",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "mcpName": "io.github.kunwar-shah/claudex",
   "description": "Persistent memory + FTS5 search for Claude Code conversations. MCP server exposes your ~/.claude/projects/ history as queryable memory for any MCP-compatible AI agent.",
   "main": "index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/kunwar-shah/claudex",
     "source": "github"
   },
-  "version": "1.3.3",
+  "version": "1.3.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@kunwarshah/claudex",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "transport": {
         "type": "stdio"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^16.3.1",
     "fastify": "^4.24.3",
     "ndjson": "^2.0.0",
-    "sqlite3": "^5.1.6",
+    "sqlite3": "^6.0.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {


### PR DESCRIPTION
Glama Dockerfile build failed on Node 22 with:

```
Error: Could not locate the bindings file. Tried:
 → /app/node_modules/sqlite3/lib/binding/node-v127-linux-x64/node_sqlite3.node
```

sqlite3 ^5.1.6 lacks prebuilts for Node 22 (NODE_MODULE_VERSION 127). v6.0.1 ships them. No API changes — sqlite3 6.x is a drop-in replacement.

Also bumps Claudex to v1.3.4 + updates server.json so MCP Registry users on Node 22+ get the working version.

## Test plan
- [ ] Glama Build re-triggers and passes
- [ ] `npm install -g @kunwarshah/claudex` works on Node 22 after publish
- [ ] Existing v1.3.3 users on Node 18/20 still work (sqlite3 6.x supports both)