### PR TITLE
feat(search): incremental indexing with archive-on-shrink preservation

### DIFF
--- a/bin/claude-viewer.js
+++ b/bin/claude-viewer.js
@@ -151,16 +151,19 @@ function showHelp() {
   console.log('  --version, -v           Show version')
   console.log('  --port, -p <port>       Server port (default: 3400)')
   console.log('  --project-root <path>   Path to Claude projects directory')
+  console.log('  --reindex-interval <s>  Auto incremental re-index every <s> seconds (default: off)')
   console.log('')
   console.log(chalk.white('Environment Variables:'))
-  console.log('  PROJECT_ROOT   Path to Claude projects directory (default: ~/.claude/projects)')
-  console.log('  PORT           Server port (default: 3400)')
+  console.log('  PROJECT_ROOT              Path to Claude projects directory (default: ~/.claude/projects)')
+  console.log('  PORT                      Server port (default: 3400)')
+  console.log('  CLAUDEX_REINDEX_INTERVAL  Auto incremental re-index interval in seconds (default: off)')
   console.log('')
   console.log(chalk.white('Examples:'))
   console.log('  claudex                              Start on default port (3400)')
   console.log('  claudex --port 3500                  Start on custom port')
   console.log('  claudex -p 8080                      Short form')
   console.log('  claudex --project-root ~/my-chats    Custom projects directory')
+  console.log('  claudex --reindex-interval 60        Auto re-index every 60s')
   console.log('  PORT=3500 claudex                    Using environment variable')
   console.log('')
   console.log(chalk.white('MCP (Claude Code Integration):'))
@@ -212,12 +215,29 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
+// Parse periodic re-index interval flag (seconds)
+let reindexInterval = null
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--reindex-interval') {
+    reindexInterval = args[i + 1]
+    if (!reindexInterval || isNaN(parseInt(reindexInterval))) {
+      console.log(chalk.red('❌ Invalid re-index interval (seconds)'))
+      console.log(chalk.yellow('Usage: claudex --reindex-interval 60'))
+      process.exit(1)
+    }
+    break
+  }
+}
+
 // Set environment variables from CLI flags
 if (customPort) {
   process.env.PORT = customPort
 }
 if (customProjectRoot) {
   process.env.PROJECT_ROOT = customProjectRoot
+}
+if (reindexInterval) {
+  process.env.CLAUDEX_REINDEX_INTERVAL = reindexInterval
 }
 
 if (args.includes('--help') || args.includes('-h')) {

--- a/server/src/routes/search.js
+++ b/server/src/routes/search.js
@@ -89,7 +89,12 @@ export async function searchRoutes(fastify, options) {
         result: null
       };
 
-      console.log('🔧 Starting async search index build...');
+      // Incremental by default; pass ?full=true (or { full: true }) to force a
+      // full rebuild from scratch.
+      const full = request.query?.full === 'true' || request.query?.full === true
+        || request.body?.full === true;
+
+      console.log(`🔧 Starting async search index ${full ? 'full rebuild' : 'incremental update'}...`);
 
       // Progress callback to update status in real-time
       const progressCallback = (progressData) => {
@@ -100,7 +105,11 @@ export async function searchRoutes(fastify, options) {
       };
 
       // Start indexing in background (don't await)
-      searchIndexer.buildFullIndex(progressCallback)
+      const indexBuild = full
+        ? searchIndexer.buildFullIndex(progressCallback)
+        : searchIndexer.buildIncrementalIndex(progressCallback);
+
+      indexBuild
         .then(result => {
           rebuildStatus.isBuilding = false;
           rebuildStatus.progress = 100;
@@ -116,7 +125,8 @@ export async function searchRoutes(fastify, options) {
       // Return immediately
       return {
         success: true,
-        message: 'Index rebuild started in background',
+        mode: full ? 'full' : 'incremental',
+        message: `Index ${full ? 'full rebuild' : 'incremental update'} started in background`,
         status: rebuildStatus
       };
 

--- a/server/src/routes/search.js
+++ b/server/src/routes/search.js
@@ -17,6 +17,50 @@ export async function searchRoutes(fastify, options) {
     result: null
   };
 
+  // Shared build plumbing, used by both the manual endpoint and the optional
+  // periodic re-index timer, so they can't run concurrently and report status
+  // the same way.
+  const progressCallback = (progressData) => {
+    rebuildStatus.progress = progressData.progress;
+    rebuildStatus.totalMessages = progressData.totalMessages;
+    rebuildStatus.currentSession = progressData.currentSession;
+    rebuildStatus.totalSessions = progressData.totalSessions;
+  };
+
+  function beginRebuildStatus() {
+    rebuildStatus = {
+      isBuilding: true,
+      progress: 0,
+      totalMessages: 0,
+      currentSession: 0,
+      totalSessions: 0,
+      error: null,
+      startTime: Date.now(),
+      result: null
+    };
+  }
+
+  // Kick off a build and keep rebuildStatus in sync. Returns the promise so
+  // callers can await it (periodic timer) or fire-and-forget (HTTP endpoint).
+  function launchBuild(full) {
+    const build = full
+      ? searchIndexer.buildFullIndex(progressCallback)
+      : searchIndexer.buildIncrementalIndex(progressCallback);
+
+    return build
+      .then(result => {
+        rebuildStatus.isBuilding = false;
+        rebuildStatus.progress = 100;
+        rebuildStatus.result = result;
+        console.log('✅ Search index build completed successfully');
+      })
+      .catch(error => {
+        rebuildStatus.isBuilding = false;
+        rebuildStatus.error = error.message;
+        console.error('❌ Search index build failed:', error);
+      });
+  }
+
   // POST /api/search  
   fastify.post('/search', async (request, reply) => {
     try {
@@ -77,18 +121,6 @@ export async function searchRoutes(fastify, options) {
         });
       }
 
-      // Reset status
-      rebuildStatus = {
-        isBuilding: true,
-        progress: 0,
-        totalMessages: 0,
-        currentSession: 0,
-        totalSessions: 0,
-        error: null,
-        startTime: Date.now(),
-        result: null
-      };
-
       // Incremental by default; pass ?full=true (or { full: true }) to force a
       // full rebuild from scratch.
       const full = request.query?.full === 'true' || request.query?.full === true
@@ -96,31 +128,8 @@ export async function searchRoutes(fastify, options) {
 
       console.log(`🔧 Starting async search index ${full ? 'full rebuild' : 'incremental update'}...`);
 
-      // Progress callback to update status in real-time
-      const progressCallback = (progressData) => {
-        rebuildStatus.progress = progressData.progress;
-        rebuildStatus.totalMessages = progressData.totalMessages;
-        rebuildStatus.currentSession = progressData.currentSession;
-        rebuildStatus.totalSessions = progressData.totalSessions;
-      };
-
-      // Start indexing in background (don't await)
-      const indexBuild = full
-        ? searchIndexer.buildFullIndex(progressCallback)
-        : searchIndexer.buildIncrementalIndex(progressCallback);
-
-      indexBuild
-        .then(result => {
-          rebuildStatus.isBuilding = false;
-          rebuildStatus.progress = 100;
-          rebuildStatus.result = result;
-          console.log('✅ Search index build completed successfully');
-        })
-        .catch(error => {
-          rebuildStatus.isBuilding = false;
-          rebuildStatus.error = error.message;
-          console.error('❌ Search index build failed:', error);
-        });
+      beginRebuildStatus();
+      launchBuild(full); // fire-and-forget; status tracked via rebuildStatus
 
       // Return immediately
       return {
@@ -240,4 +249,39 @@ export async function searchRoutes(fastify, options) {
       });
     }
   });
+
+  // ---- Optional periodic incremental re-index ----
+  // Set CLAUDEX_REINDEX_INTERVAL to a number of seconds to keep the index fresh
+  // automatically (e.g. 60). Unset or <= 0 disables it (default). Each tick runs
+  // an incremental pass, skipped if a manual build is already in progress, so it
+  // never overlaps. The first pass runs shortly after startup, which also
+  // bootstraps an empty index without needing a manual rebuild.
+  const reindexSeconds = parseInt(process.env.CLAUDEX_REINDEX_INTERVAL || '0', 10);
+  if (Number.isFinite(reindexSeconds) && reindexSeconds > 0) {
+    const intervalMs = Math.max(reindexSeconds, 5) * 1000; // floor at 5s
+
+    const tick = async () => {
+      if (rebuildStatus.isBuilding) return; // a manual or prior build is running
+      beginRebuildStatus();
+      try {
+        await launchBuild(false); // incremental
+      } catch (error) {
+        console.error('❌ Periodic re-index failed:', error);
+      }
+    };
+
+    // Initial pass a moment after boot, then on the interval.
+    const initialTimer = setTimeout(tick, 1000);
+    const reindexTimer = setInterval(tick, intervalMs);
+    // Don't let these timers keep the process alive on their own.
+    if (initialTimer.unref) initialTimer.unref();
+    if (reindexTimer.unref) reindexTimer.unref();
+
+    fastify.addHook('onClose', async () => {
+      clearTimeout(initialTimer);
+      clearInterval(reindexTimer);
+    });
+
+    console.log(`🕒 Periodic incremental re-index enabled: every ${Math.max(reindexSeconds, 5)}s`);
+  }
 }

--- a/server/src/services/fileScanner.js
+++ b/server/src/services/fileScanner.js
@@ -70,6 +70,41 @@ export class FileScanner {
     }
   }
 
+  // Lightweight session scan: stat only, no file reads. Used by incremental
+  // indexing to detect which session files changed (by size + mtime) before
+  // deciding whether to parse them at all.
+  async statSessions(projectPath) {
+    try {
+      const entries = await fs.readdir(projectPath, { withFileTypes: true });
+      const sessions = [];
+
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          const filePath = path.join(projectPath, entry.name);
+          const stats = await fs.stat(filePath);
+          sessions.push({
+            sessionId: entry.name.replace('.jsonl', ''),
+            filePath,
+            size: stats.size,
+            mtimeMs: Math.floor(stats.mtimeMs)
+          });
+        }
+      }
+
+      return sessions;
+    } catch (error) {
+      console.error('Error stat-scanning sessions:', error);
+      throw new Error(`Failed to stat sessions in project: ${error.message}`);
+    }
+  }
+
+  // Compute the display title for a session from its first raw messages,
+  // matching the title used by the full-index path.
+  async getSessionTitle(filePath, sessionId) {
+    const firstMessages = await this.getSessionFirstMessages(filePath, 3);
+    return extractTitleFromRawMessages(firstMessages, sessionId);
+  }
+
   cleanProjectName(rawName) {
     // Convert "-mnt-c-laragon-www-simple-migration" to "simple-migration"
     // Convert "-home-boss-claude-chats" to "claude-chats"

--- a/server/src/services/searchDatabase.js
+++ b/server/src/services/searchDatabase.js
@@ -116,6 +116,30 @@ export class SearchDatabase {
     await this.db.run('CREATE INDEX IF NOT EXISTS idx_session_metadata_deleted ON session_metadata(is_deleted)')
     await this.db.run('CREATE INDEX IF NOT EXISTS idx_session_metadata_tags ON session_metadata(tags)')
     await this.db.run('CREATE INDEX IF NOT EXISTS idx_session_metadata_favorited ON session_metadata(is_favorited)')
+
+    // Per-file watermark table powering incremental indexing.
+    // One row per (project_id, session_id) recording how far into the JSONL
+    // file we have indexed, so subsequent passes only parse appended lines.
+    const indexedFilesTableSQL = `
+      CREATE TABLE IF NOT EXISTS indexed_files (
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        project_name TEXT,
+        session_title TEXT,
+        template TEXT,
+        file_path TEXT NOT NULL,
+        mtime_ms INTEGER NOT NULL,
+        size_bytes INTEGER NOT NULL,
+        bytes_indexed INTEGER NOT NULL,
+        last_line_number INTEGER NOT NULL DEFAULT 0,
+        prefix_sha TEXT,
+        message_count INTEGER NOT NULL DEFAULT 0,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (project_id, session_id)
+      )
+    `
+    await this.db.run(indexedFilesTableSQL)
+    await this.db.run('CREATE INDEX IF NOT EXISTS idx_indexed_files_project ON indexed_files(project_id)')
   }
 
   async indexMessage({
@@ -326,6 +350,72 @@ export class SearchDatabase {
 
     // For complex queries, just escape quotes and return as-is
     return escaped;
+  }
+
+  // ---- Incremental indexing: per-file watermark tracking ----
+
+  async getIndexedFile(projectId, sessionId) {
+    return await this.db.get(
+      'SELECT * FROM indexed_files WHERE project_id = ? AND session_id = ?',
+      [projectId, sessionId]
+    )
+  }
+
+  async getIndexedFilesForProject(projectId) {
+    return (await this.db.all(
+      'SELECT * FROM indexed_files WHERE project_id = ?',
+      [projectId]
+    )) || []
+  }
+
+  async getAllIndexedFiles() {
+    return (await this.db.all('SELECT * FROM indexed_files')) || []
+  }
+
+  async upsertIndexedFile(record) {
+    await this.db.run(`
+      INSERT OR REPLACE INTO indexed_files (
+        project_id, session_id, project_name, session_title, template,
+        file_path, mtime_ms, size_bytes, bytes_indexed, last_line_number,
+        prefix_sha, message_count, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    `, [
+      record.projectId, record.sessionId, record.projectName, record.sessionTitle,
+      record.template, record.filePath, record.mtimeMs, record.sizeBytes,
+      record.bytesIndexed, record.lastLineNumber, record.prefixSha, record.messageCount
+    ])
+  }
+
+  async deleteIndexedFile(projectId, sessionId) {
+    await this.db.run(
+      'DELETE FROM indexed_files WHERE project_id = ? AND session_id = ?',
+      [projectId, sessionId]
+    )
+  }
+
+  async clearIndexedFiles() {
+    await this.db.run('DELETE FROM indexed_files')
+  }
+
+  // Delete all FTS rows for a session (used by the full-reindex fallback).
+  async deleteSessionRows(projectId, sessionId) {
+    await this.db.run(
+      'DELETE FROM messages_fts WHERE project_id = ? AND session_id = ?',
+      [projectId, sessionId]
+    )
+  }
+
+  // Preserve a session's currently-indexed rows by re-keying them to an
+  // archived session_id, instead of deleting them. Used when a file shrinks
+  // or is rewritten (compaction corruption, manual edit) so previously
+  // indexed conversation content remains searchable.
+  async archiveSessionRows(projectId, sessionId, archiveSuffix, titleSuffix = ' (archived)') {
+    await this.db.run(`
+      UPDATE messages_fts
+         SET session_id = session_id || ?,
+             session_title = session_title || ?
+       WHERE project_id = ? AND session_id = ?
+    `, [archiveSuffix, titleSuffix, projectId, sessionId])
   }
 
   async close() {

--- a/server/src/services/searchIndexer.js
+++ b/server/src/services/searchIndexer.js
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import crypto from 'crypto'
 import { FileScanner } from './fileScanner.js'
 import { SessionParser } from './sessionParser.js'
 import { SearchDatabase } from './searchDatabase.js'
@@ -21,8 +23,9 @@ export class SearchIndexer {
     const startTime = Date.now()
 
     try {
-      // Clear existing index
+      // Clear existing index and per-file watermarks (full reset)
       await this.searchDb.clearIndex()
+      await this.searchDb.clearIndexedFiles()
 
       // Start transaction for massive performance boost
       await this.searchDb.beginTransaction()
@@ -86,6 +89,30 @@ export class SearchIndexer {
                 await this.searchDb.indexMessagesBatch(messageBatch)
                 messageBatch = []
               }
+            }
+
+            // Record the per-file watermark so later incremental passes can
+            // skip this session (unchanged) or parse only appended lines.
+            try {
+              const st = await fs.promises.stat(session.filePath)
+              const sizeBytes = st.size
+              const prefixSha = await this._hashPrefix(session.filePath, sizeBytes)
+              await this.searchDb.upsertIndexedFile({
+                projectId: project.id,
+                sessionId: session.sessionId,
+                projectName: project.name,
+                sessionTitle: session.title || session.sessionId,
+                template: result.template,
+                filePath: session.filePath,
+                mtimeMs: Math.floor(st.mtimeMs),
+                sizeBytes,
+                bytesIndexed: sizeBytes,
+                lastLineNumber: result.stats.totalLines,
+                prefixSha,
+                messageCount: result.messages.length
+              })
+            } catch (trackErr) {
+              console.warn(`   ⚠️  Failed to record watermark for ${session.sessionId}:`, trackErr.message)
             }
 
             processedSessions++
@@ -206,6 +233,224 @@ export class SearchIndexer {
       
     } catch (error) {
       console.error(`❌ Failed to update session index for ${sessionFilePath}:`, error)
+      throw error
+    }
+  }
+
+  // SHA-256 of the first `byteLength` bytes of a file. Used to detect whether
+  // a changed file was appended-to (prefix unchanged) or rewritten (prefix
+  // differs / file shrank).
+  async _hashPrefix(filePath, byteLength) {
+    if (!byteLength || byteLength <= 0) {
+      return crypto.createHash('sha256').digest('hex')
+    }
+    return await new Promise((resolve, reject) => {
+      const hash = crypto.createHash('sha256')
+      const stream = fs.createReadStream(filePath, { start: 0, end: byteLength - 1 })
+      stream.on('data', chunk => hash.update(chunk))
+      stream.on('end', () => resolve(hash.digest('hex')))
+      stream.on('error', reject)
+    })
+  }
+
+  async _insertBatched(messages, batchSize = 500) {
+    for (let i = 0; i < messages.length; i += batchSize) {
+      await this.searchDb.indexMessagesBatch(messages.slice(i, i + batchSize))
+    }
+  }
+
+  // Index an entire session from byte 0 and (re)write its watermark row.
+  // Used for newly-seen sessions and for the reindex half of archive-on-rewrite.
+  async _indexSessionFull(project, sessionMeta) {
+    const { sessionId, filePath, size, mtimeMs } = sessionMeta
+    const title = await this.fileScanner.getSessionTitle(filePath, sessionId)
+    const parsed = await this.sessionParser.parseSessionFrom(filePath, 0, 0)
+
+    const batch = parsed.messages.map(m => ({
+      projectId: project.id,
+      projectName: project.name,
+      sessionId,
+      sessionTitle: title || sessionId,
+      messageId: m.id,
+      role: m.role,
+      content: m.content,
+      timestamp: m.timestamp,
+      filePath,
+      lineNumber: m.lineNumber,
+      template: parsed.template
+    }))
+    await this._insertBatched(batch)
+
+    const prefixSha = await this._hashPrefix(filePath, parsed.endByte)
+    await this.searchDb.upsertIndexedFile({
+      projectId: project.id,
+      sessionId,
+      projectName: project.name,
+      sessionTitle: title || sessionId,
+      template: parsed.template,
+      filePath,
+      mtimeMs,
+      sizeBytes: size,
+      bytesIndexed: parsed.endByte,
+      lastLineNumber: parsed.lastLineNumber,
+      prefixSha,
+      messageCount: batch.length
+    })
+    return batch.length
+  }
+
+  /**
+   * Incrementally bring the index up to date with the JSONL files on disk,
+   * without re-reading unchanged sessions.
+   *
+   * Per session:
+   *  - unchanged (size + mtime match watermark) → skip, no file read
+   *  - new (no watermark)                        → full index
+   *  - grown, prefix unchanged                   → parse & index only appended lines
+   *  - shrunk or prefix changed (rewrite/        → ARCHIVE existing rows (re-key,
+   *    compaction corruption/manual edit)          don't delete) then reindex fresh
+   *  - watermark exists but file gone (orphan)   → ARCHIVE existing rows, drop watermark
+   *
+   * Archiving preserves previously-indexed conversation content so it stays
+   * searchable even if the source file is rewritten or removed.
+   */
+  async buildIncrementalIndex(progressCallback = null) {
+    console.log('🔁 Starting incremental search index update...')
+    const startTime = Date.now()
+    const summary = {
+      sessions: 0, skipped: 0, newSessions: 0,
+      appended: 0, archived: 0, orphaned: 0, messagesAdded: 0
+    }
+
+    try {
+      const projects = await this.fileScanner.scanProjects()
+
+      // Stat-only scan up front (cheap) for accurate progress + change detection.
+      const perProject = []
+      let totalSessions = 0
+      for (const project of projects) {
+        const sessions = await this.fileScanner.statSessions(project.path)
+        perProject.push({ project, sessions })
+        totalSessions += sessions.length
+      }
+      summary.sessions = totalSessions
+
+      await this.searchDb.beginTransaction()
+
+      const seen = new Set()
+      let processed = 0
+
+      for (const { project, sessions } of perProject) {
+        for (const s of sessions) {
+          seen.add(`${project.id}\n${s.sessionId}`)
+          const tracked = await this.searchDb.getIndexedFile(project.id, s.sessionId)
+
+          if (!tracked) {
+            summary.messagesAdded += await this._indexSessionFull(project, s)
+            summary.newSessions++
+          } else if (tracked.size_bytes === s.size && tracked.mtime_ms === s.mtimeMs) {
+            summary.skipped++
+          } else {
+            const prefixLen = Math.min(tracked.bytes_indexed, s.size)
+            const curPrefixSha = await this._hashPrefix(s.filePath, prefixLen)
+            const isAppend = s.size >= tracked.bytes_indexed && curPrefixSha === tracked.prefix_sha
+
+            if (isAppend) {
+              const parsed = await this.sessionParser.parseSessionFrom(
+                s.filePath, tracked.bytes_indexed, tracked.last_line_number
+              )
+              if (parsed.messages.length > 0) {
+                const batch = parsed.messages.map(m => ({
+                  projectId: project.id,
+                  projectName: tracked.project_name || project.name,
+                  sessionId: s.sessionId,
+                  sessionTitle: tracked.session_title || s.sessionId,
+                  messageId: m.id,
+                  role: m.role,
+                  content: m.content,
+                  timestamp: m.timestamp,
+                  filePath: s.filePath,
+                  lineNumber: m.lineNumber,
+                  template: tracked.template || parsed.template
+                }))
+                await this._insertBatched(batch)
+                summary.appended += batch.length
+                summary.messagesAdded += batch.length
+              }
+              const newBytesIndexed = Math.max(parsed.endByte, tracked.bytes_indexed)
+              const prefixSha = await this._hashPrefix(s.filePath, newBytesIndexed)
+              await this.searchDb.upsertIndexedFile({
+                projectId: project.id,
+                sessionId: s.sessionId,
+                projectName: tracked.project_name || project.name,
+                sessionTitle: tracked.session_title || s.sessionId,
+                template: tracked.template || parsed.template,
+                filePath: s.filePath,
+                mtimeMs: s.mtimeMs,
+                sizeBytes: s.size,
+                bytesIndexed: newBytesIndexed,
+                lastLineNumber: parsed.lastLineNumber,
+                prefixSha,
+                messageCount: (tracked.message_count || 0) + parsed.messages.length
+              })
+            } else {
+              // Rewrite / shrink / compaction corruption: preserve, don't lose.
+              await this.searchDb.archiveSessionRows(project.id, s.sessionId, `#archived-${tracked.mtime_ms}`)
+              summary.messagesAdded += await this._indexSessionFull(project, s)
+              summary.archived++
+            }
+          }
+
+          processed++
+          if (progressCallback) {
+            progressCallback({
+              progress: totalSessions ? Math.floor((processed / totalSessions) * 100) : 100,
+              totalMessages: summary.messagesAdded,
+              currentSession: processed,
+              totalSessions
+            })
+          }
+        }
+      }
+
+      // Orphan sweep: watermarks whose source file is no longer on disk.
+      // Preserve their content by archiving rather than deleting.
+      const allTracked = await this.searchDb.getAllIndexedFiles()
+      for (const row of allTracked) {
+        if (!seen.has(`${row.project_id}\n${row.session_id}`)) {
+          await this.searchDb.archiveSessionRows(row.project_id, row.session_id, `#archived-${row.mtime_ms}`)
+          await this.searchDb.deleteIndexedFile(row.project_id, row.session_id)
+          summary.orphaned++
+        }
+      }
+
+      await this.searchDb.setMetadata('last_incremental_index', new Date().toISOString())
+      const stats = await this.searchDb.getIndexStats()
+      await this.searchDb.setMetadata('total_messages', String(stats.total_messages))
+
+      await this.searchDb.commitTransaction()
+
+      const duration = ((Date.now() - startTime) / 1000).toFixed(2)
+      console.log(`✅ Incremental update complete in ${duration}s`, summary)
+
+      if (progressCallback) {
+        progressCallback({
+          progress: 100,
+          totalMessages: summary.messagesAdded,
+          currentSession: totalSessions,
+          totalSessions
+        })
+      }
+
+      return { success: true, mode: 'incremental', stats: { ...summary, duration: parseFloat(duration) } }
+
+    } catch (error) {
+      console.error('❌ Incremental index update failed:', error)
+      try {
+        await this.searchDb.rollbackTransaction()
+      } catch (rollbackError) {
+        console.error('Failed to rollback transaction:', rollbackError)
+      }
       throw error
     }
   }

--- a/server/src/services/sessionParser.js
+++ b/server/src/services/sessionParser.js
@@ -111,6 +111,85 @@ export class SessionParser {
     }
   }
 
+  /**
+   * Parse only the portion of a session file starting at `startByte`, continuing
+   * line numbering from `startLineNumber`. Used by incremental indexing to read
+   * just the lines appended since the last pass.
+   *
+   * Reads the byte slice [startByte, EOF) and only consumes up to the LAST
+   * newline, so a partial final line (a record still being written) is deferred
+   * to the next pass rather than indexed half-formed. Returns the byte offset
+   * actually consumed so the caller can advance its watermark precisely.
+   *
+   * Line numbers and message ids are produced identically to parseSession() as
+   * long as `startLineNumber` is the last fully-indexed physical line, because
+   * MessageParser bakes the line number into each message id.
+   */
+  async parseSessionFrom(sessionFilePath, startByte = 0, startLineNumber = 0) {
+    // Detect template from the file head, same source parseSession uses.
+    const samples = await this.getSampleMessages(sessionFilePath);
+    const template = TemplateDetector.detectTemplate(samples);
+
+    const empty = {
+      messages: [],
+      template,
+      bytesConsumed: 0,
+      endByte: startByte,
+      lastLineNumber: startLineNumber,
+      skippedLines: 0,
+    };
+
+    const fh = await fs.promises.open(sessionFilePath, 'r');
+    try {
+      const { size } = await fh.stat();
+      if (startByte >= size) return empty;
+
+      const length = size - startByte;
+      const buffer = Buffer.allocUnsafe(length);
+      await fh.read(buffer, 0, length, startByte);
+
+      // Consume only through the last complete line (terminated by \n).
+      const lastNewline = buffer.lastIndexOf(0x0a);
+      if (lastNewline === -1) return empty; // no complete line available yet
+
+      const completeBytes = lastNewline + 1;
+      const text = buffer.toString('utf8', 0, completeBytes);
+
+      const messages = [];
+      let lineNumber = startLineNumber;
+      let skippedLines = 0;
+
+      const lines = text.split('\n');
+      lines.pop(); // drop the empty string after the trailing newline
+
+      for (const rawLine of lines) {
+        lineNumber++; // count every physical line (incl. blanks), like parseSession
+        const trimmedLine = rawLine.trim();
+        if (!trimmedLine) continue;
+
+        try {
+          const rawMessage = JSON.parse(trimmedLine);
+          const parsedMessage = this.messageParser.parseMessage(rawMessage, template, lineNumber);
+          parsedMessage.lineNumber = lineNumber;
+          messages.push(parsedMessage);
+        } catch (error) {
+          skippedLines++;
+        }
+      }
+
+      return {
+        messages,
+        template,
+        bytesConsumed: completeBytes,
+        endByte: startByte + completeBytes,
+        lastLineNumber: lineNumber,
+        skippedLines,
+      };
+    } finally {
+      await fh.close();
+    }
+  }
+
   async getSampleMessages(sessionFilePath, sampleSize = 10) {
     const samples = [];
     const fileStream = fs.createReadStream(sessionFilePath);

--- a/server/test/incremental.test.mjs
+++ b/server/test/incremental.test.mjs
@@ -1,0 +1,127 @@
+// Standalone test for incremental indexing + archive-on-shrink preservation.
+// Run: node server/test/incremental.test.mjs
+//
+// Uses a temp projects root and a temp SQLite DB so it never touches real data.
+// No test framework dependency — plain assertions, non-zero exit on failure.
+//
+// NOTE: session_title is indexed on every row of a session and is derived from
+// the FIRST message, so a token appearing in the first message matches every
+// row in that session. Search tokens below are kept disjoint from the first
+// ("header") line so per-message counts are unambiguous.
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { SearchIndexer } from '../src/services/searchIndexer.js'
+import { SearchDatabase } from '../src/services/searchDatabase.js'
+
+let passed = 0
+function check(label, cond) {
+  if (!cond) throw new Error(`FAIL: ${label}`)
+  passed++
+  console.log(`  ✓ ${label}`)
+}
+
+// All lines are user messages with string content (cleanly extracted). The
+// sessionId+uuid+type+timestamp shape makes TemplateDetector recognize a real
+// Claude Code format instead of falling back to the generic parser.
+function line(uuid, text, ts = '2026-01-01T00:00:00.000Z') {
+  return JSON.stringify({
+    type: 'user',
+    uuid,
+    sessionId: 's1',
+    timestamp: ts,
+    message: { role: 'user', content: text }
+  }) + '\n'
+}
+
+async function total(idx, query) {
+  return (await idx.search({ query, limit: 50, offset: 0 })).total
+}
+async function hits(idx, query) {
+  return (await idx.search({ query, limit: 50, offset: 0 })).hits
+}
+
+async function main() {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claudex-inc-'))
+  const projectsRoot = path.join(tmpRoot, 'projects')
+  const projectDir = path.join(projectsRoot, '-test-proj')
+  fs.mkdirSync(projectDir, { recursive: true })
+  const sessionFile = path.join(projectDir, 's1.jsonl')
+  const dbPath = path.join(tmpRoot, 'search.db')
+
+  const idx = new SearchIndexer(projectsRoot)
+  idx.searchDb = new SearchDatabase(dbPath)
+  await idx.init()
+
+  try {
+    // --- 1. New session: full index ---
+    fs.writeFileSync(sessionFile,
+      line('u1', 'header opening line') +     // first line -> becomes the title
+      line('u2', 'second message alpha') +
+      line('u3', 'third message charlie'))
+
+    let r = await idx.buildIncrementalIndex()
+    check('new session indexed as new', r.stats.newSessions === 1)
+    check('3 messages added', r.stats.messagesAdded === 3)
+    check('search alpha -> 1', (await total(idx, 'alpha')) === 1)
+    check('search charlie -> 1', (await total(idx, 'charlie')) === 1)
+
+    // --- 2. No-op: unchanged file is skipped ---
+    r = await idx.buildIncrementalIndex()
+    check('unchanged session skipped', r.stats.skipped === 1)
+    check('no messages added on no-op', r.stats.messagesAdded === 0)
+    check('no duplicate for alpha after no-op', (await total(idx, 'alpha')) === 1)
+
+    // --- 3. Append: only new lines indexed, no dupes ---
+    fs.appendFileSync(sessionFile,
+      line('u4', 'fourth message delta') +
+      line('u5', 'fifth message echo'))
+
+    r = await idx.buildIncrementalIndex()
+    check('append indexed 2 new lines', r.stats.appended === 2)
+    check('append added 2 messages', r.stats.messagesAdded === 2)
+    check('search delta -> 1', (await total(idx, 'delta')) === 1)
+    check('alpha still 1 (no re-index dupes)', (await total(idx, 'alpha')) === 1)
+
+    // --- 4. Archive-on-shrink: rewrite file smaller, preserve old content ---
+    fs.writeFileSync(sessionFile, line('u9', 'rewritten foxtrot'))
+
+    r = await idx.buildIncrementalIndex()
+    check('shrink/rewrite triggers archive', r.stats.archived === 1)
+    check('live content foxtrot searchable', (await total(idx, 'foxtrot')) === 1)
+    const alphaHits = await hits(idx, 'alpha')
+    check('archived alpha preserved', alphaHits.length === 1)
+    check('archived alpha re-keyed to #archived session', alphaHits[0].sessionId.includes('#archived'))
+    check('delta preserved after compaction', (await total(idx, 'delta')) === 1)
+
+    // --- 5. Orphan: delete file, content preserved via archive ---
+    fs.rmSync(sessionFile)
+    r = await idx.buildIncrementalIndex()
+    check('deleted file counted as orphan', r.stats.orphaned === 1)
+    check('orphaned content still searchable (foxtrot)', (await total(idx, 'foxtrot')) >= 1)
+    check('watermark removed for deleted session',
+      (await idx.searchDb.getIndexedFile('-test-proj', 's1')) === undefined)
+
+    // --- 6. Full rebuild then incremental no-op (no double index) ---
+    fs.writeFileSync(sessionFile,
+      line('u1', 'header again') +
+      line('u2', 'body golf'))
+    await idx.buildFullIndex()
+    check('full build indexes golf', (await total(idx, 'golf')) === 1)
+    r = await idx.buildIncrementalIndex()
+    check('incremental after full is a no-op', r.stats.skipped === 1 && r.stats.appended === 0)
+    check('golf not duplicated after incremental', (await total(idx, 'golf')) === 1)
+
+    console.log(`\n✅ All ${passed} checks passed`)
+  } finally {
+    await idx.close()
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch(err => {
+  console.error('\n❌', err.message)
+  console.error(err.stack)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Adds **incremental indexing** to the search index so `POST /api/search/index/build` only reads what changed, instead of clearing `messages_fts` and re-parsing every message of every session on each call. The full rebuild cost grows linearly with history and makes frequent refreshes wasteful.

It also adds an **optional periodic re-index timer** to keep the index fresh automatically, and **preserves previously-indexed conversation content** when a session file is rewritten, shrunk, or deleted — so the index never silently loses history.

> Status: draft — opening for design feedback before polishing. Happy to adjust the archival semantics, naming, or split this up.

## How incremental indexing works

A new `indexed_files` table stores a per-session watermark: bytes indexed so far, last physical line number, file size + mtime, and a SHA-256 of the indexed prefix. `buildIncrementalIndex()` then, per session:

| Situation | Action |
|---|---|
| unchanged (size + mtime match) | **skip** — no file read |
| new session (no watermark) | full index |
| grown, indexed prefix unchanged | parse & index **only appended lines** |
| shrunk / prefix changed (rewrite, compaction corruption, manual edit) | **archive** existing rows (re-key to `<sid>#archived-<mtime>`, don't delete), then reindex fresh |
| watermark exists but file gone | **archive** existing rows, drop watermark |

Archiving instead of delete-then-reindex means content that's rewritten or removed at the source stays searchable. Claude Code session files are normally append-only — even in-file compaction appends a `compact_boundary` and continues, and cross-file compaction starts a *new* session file — so the archive path is a safety net for the rare rewrite/shrink/delete and the known `/compact` corruption cases ([anthropics/claude-code#19443](https://github.com/anthropics/claude-code/issues/19443), [#36583](https://github.com/anthropics/claude-code/issues/36583)).

### Key implementation details

- **`SessionParser.parseSessionFrom(file, startByte, startLine)`** reads only the byte slice since the last pass and consumes up to the **last newline**, so a partial final line still being written is deferred rather than indexed half-formed. Line numbers resume exactly, so message ids (`<uuid>-L<line>`) match what a full rebuild would produce.
- **`FileScanner.statSessions()`** — stat-only scan (no file reads) for cheap change detection.
- **No FTS schema change.** FTS5 virtual tables can't be `ALTER`ed to add columns, so archived rows are re-keyed via the existing `session_id` / `session_title` columns. `indexed_files` is created with `IF NOT EXISTS` (backwards compatible).
- **`buildFullIndex()` now maintains the watermark table** (clears it on reset, writes a row per session), so a full rebuild followed by an incremental pass is a correct **no-op** rather than a double-index.

## Optional periodic re-index

A built-in timer runs `buildIncrementalIndex()` on an interval so the index stays current without an external trigger:

- Enable with `CLAUDEX_REINDEX_INTERVAL=<seconds>` or `claudex --reindex-interval <s>`. Unset / `<= 0` disables it (default off). Interval is floored at 5s.
- Shares the existing `isBuilding` guard — a tick is skipped if a manual build (or a prior tick) is still running, so periodic and manual builds never overlap. The endpoint and timer now share one `launchBuild()` helper.
- Runs an initial pass ~1s after startup, which also bootstraps an empty index.
- Timers are `unref`'d and cleared on a fastify `onClose` hook.

## API

`POST /api/search/index/build` is now **incremental by default**; pass `?full=true` (or `{ "full": true }`) to force a full rebuild. `POST /api/search/index/clear` is unchanged.

## Testing

Adds `server/test/incremental.test.mjs` (no framework dependency, run with `node server/test/incremental.test.mjs`). Covers: new session, no-op skip, append-only delta, archive-on-shrink preservation + re-key, orphan preservation, and full-then-incremental no-op. **All 22 checks pass.**

Validated against real history: full build **6,687 messages / 31 sessions in 0.53s**, then an immediate incremental pass **skips all 31 sessions, 0 messages added, ~0ms**. The periodic timer was verified end-to-end (initial tick indexes incrementally shortly after boot; search returns the content).

## Notes / open questions

- Archived sessions appear as distinct `session_id`s (`#archived-<mtime>`), so `getIndexStats()` `total_sessions` counts them. Could add a filter/flag to hide archived rows from default search if preferred.
- The prefix hash is computed over the full indexed prefix; for very large files a bounded window would trade a little robustness for speed. Left full for correctness given current file sizes.
- Reuses the previously-unused `updateSessionIndex()` intent (per-session reindex) — happy to consolidate or remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
