### PR TITLE
chore: revert PR #48 (MseeP.ai marketing badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/kunwar-shah-claudex-badge.png)](https://mseep.ai/app/kunwar-shah-claudex)
-
 <div align="center">
   <img src="docs/logo-sm.png" alt="Claudex Logo" width="180">
 


### PR DESCRIPTION
Reverts #48.

## Why

PR #48 added a `MseeP.ai Security Assessment Badge` to the top of the README. On audit:

- **Author signal weak**: `mseep-ai` is a bot account (created Apr 2025, 1,428 repos in 18 months, 6 followers, mass-forks every public MCP server it finds).
- **Tracking pixel**: badge image is hosted at `mseep.net`. Every GitHub README view fires a request to their analytics, giving them traffic data + the ability to claim adoption metrics in their pitch material.
- **Hollow "Security Assessment" claim**: no actual security audit was performed. The badge is automatically generated by scraping the public repo. Pattern matches the well-documented "trust badge" SEO play.
- **Not equivalent to Glama**: the Glama badge (PR #5642 on punkpeye/awesome-mcp-servers) is backed by a real Dockerfile build + MCP introspection check that we explicitly opted into. MseeP-ai did neither.

## Policy going forward

Adding a corresponding rule to global CLAUDE.md: external README badges only accepted if (a) the issuer performs actual validation, (b) the image is served from a trusted CDN, and (c) the author is not a bot account.

## Effect

Removes 2 lines from the top of README.md. No code impact.